### PR TITLE
chore: remove dead "Feed" link from header

### DIFF
--- a/src/views/layouts/main.handlebars
+++ b/src/views/layouts/main.handlebars
@@ -27,7 +27,6 @@
           <a href="/releases">All Releases</a>
           <a href="/history">History</a>
           <a href="https://electronjs.org" target="_blank" rel="noopener noreferrer">Website</a>
-          <a href="https://electronjs.org/releases.xml" target="_blank" rel="noopener noreferrer">Feed</a>
         </div>
       </div>
     </nav>


### PR DESCRIPTION
This went dead with the new website. Given the lack of noise about it, let's just remove the link, can always be added back if the RSS feed gets revived.