### PR TITLE
chore: extend E22 stable supported release

### DIFF
--- a/src/routes/home.js
+++ b/src/routes/home.js
@@ -74,7 +74,9 @@ router.get(
     );
     const lastStable = releases.find((r) => semver.parse(r.version).prerelease.length === 0);
     const stableMajor = semver.parse(lastStable.version).major;
-    const latestSupported = [stableMajor, stableMajor - 1, stableMajor - 2].map((major) =>
+    // TODO: We're supporting Electron 22 until Oct. 10, 2023.
+    // Remove this hardcoded value at that time.
+    const latestSupported = [stableMajor, stableMajor - 1, stableMajor - 2, 22].map((major) =>
       releases.find((r) => semver.parse(r.version).major === major),
     );
     if (semver.parse(lastPreRelease.version).major <= stableMajor) {


### PR DESCRIPTION
Continue to list E22 as a stable release on the home page.