### PR TITLE
fix: show when there are no release notes for a comparison

### DIFF
--- a/src/routes/release.js
+++ b/src/routes/release.js
@@ -50,11 +50,18 @@ Handlebars.registerHelper('markdownMergeHeaders', function (contentArr) {
     }
   }
   let generatedNotes = '# Combined Release Notes\n\n';
-  for (const knownSection of knownSections.concat(Object.keys(groups))) {
-    if (!groups[knownSection]) continue;
-    generatedNotes += `## ${knownSection}\n\n${groups[knownSection]}\n`;
-    delete groups[knownSection];
+
+  const hasReleaseNotes = Object.values(groups).some((v) => v !== '');
+  if (hasReleaseNotes) {
+    for (const knownSection of knownSections.concat(Object.keys(groups))) {
+      if (!groups[knownSection]) continue;
+      generatedNotes += `## ${knownSection}\n\n${groups[knownSection]}\n`;
+      delete groups[knownSection];
+    }
+  } else {
+    generatedNotes += 'There were no release notes for this version comparison.';
   }
+
   return DOMPurify.sanitize(md.render(generatedNotes));
 });
 


### PR DESCRIPTION
Closes https://github.com/electron/release-status/issues/24

Fixes an issue where it could be unclear to the user if a given version diff had release notes.

<img width="1174" alt="Screenshot 2023-12-13 at 1 26 31 PM" src="https://github.com/electron/release-status/assets/2036040/fb833e1b-c328-4588-9cab-45c40f690b6e">
