### PR TITLE
fix: improve error validation

### DIFF
--- a/src/routes/pr.js
+++ b/src/routes/pr.js
@@ -161,6 +161,12 @@ async function getPRReleaseStatus(prNumber) {
   };
 }
 
+router.get('/is-valid/:number', async (req, res) => {
+  const prNumber = parseInt(req.params.number, 10);
+  const valid = prNumber > 0 && !!(await getPR(prNumber));
+  return res.json({ valid });
+});
+
 router.get(
   '/:number',
   a(async (req, res) => {

--- a/src/static/css/pr-lookup.css
+++ b/src/static/css/pr-lookup.css
@@ -1,4 +1,4 @@
-.lookup-container {
+.lookup-input {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -6,7 +6,7 @@
   padding: 20px;
 }
 
-#lookupInput {
+#input {
   padding: 10px;
   border-radius: 5px;
   border: 1px solid #ccc;
@@ -24,4 +24,14 @@ button {
 
 button:hover {
   background-color: #0d4a59;
+}
+
+.error {
+  color: red;
+  justify-content: center;
+  display: flex;
+}
+
+.error:empty {
+  display: none;
 }

--- a/src/views/pr-lookup.handlebars
+++ b/src/views/pr-lookup.handlebars
@@ -1,11 +1,29 @@
-<div class="lookup-container">
-  <input id="lookupInput" type="text" placeholder="Look Up a PR...">
+<div>
+<div class="lookup-input">
+  <input id="input" type="text" placeholder="12345">
   <button onclick="lookup()">Search</button>
+</div>
+<p class="error"></p>
 </div>
 
 <script>
-  function lookup() {
-    const { value } = document.getElementById('lookupInput');
-    window.location = '/pr/' + encodeURIComponent(value);
+  async function lookup() {
+    const error = document.getElementById('error');
+
+    const { value } = document.getElementById('input');
+    const prNumber = parseInt(value, 10);
+
+    if (isNaN(prNumber) || prNumber < 0) {
+      error.textContent = 'Invalid PR number - must be a positive number';
+      return;
+    }
+
+    const { valid } = await fetch(`/pr/is-valid/${prNumber}`).then(res => res.json());
+    if (!valid) {
+      error.textContent = `PR #${prNumber} not found - please check the number and try again`;
+      return;
+    }
+
+    window.location = `/pr/${encodeURIComponent(prNumber)}`;
   }
 </script>


### PR DESCRIPTION
Follow-up to https://github.com/electron/release-status/pull/26.

Previously, if a user input an invalid PR or a PR that didn't exist, they would be redirected to the homepage. They should instead see some kind of error message indicating what went wrong, which they now will.

<img width="540" alt="Screenshot 2023-12-14 at 9 09 03 PM" src="https://github.com/electron/release-status/assets/2036040/855a624f-a70c-4fd2-84d3-4595e3a37e19">

<img width="695" alt="Screenshot 2023-12-14 at 9 08 55 PM" src="https://github.com/electron/release-status/assets/2036040/1125babc-0511-4269-b77d-2458e8257c4f">

