### PR TITLE
fix: set ID for PR lookup error element

### DIFF
--- a/src/views/pr-lookup.handlebars
+++ b/src/views/pr-lookup.handlebars
@@ -3,7 +3,7 @@
   <input id="input" type="text" placeholder="12345">
   <button onclick="lookup()">Search</button>
 </div>
-<p class="error"></p>
+<p class="error" id="error"></p>
 </div>
 
 <script>


### PR DESCRIPTION
Follow-up to #33, the final changes before merge broke the element selector.