### PR TITLE
ci: generate release calendar events for an Electron major

### DIFF
--- a/.github/workflows/release-calendar-events.yml
+++ b/.github/workflows/release-calendar-events.yml
@@ -1,0 +1,91 @@
+name: Release Calendar Events
+
+on:
+  workflow_dispatch:
+    inputs:
+      major:
+        description: Electron major (e.g. 30)
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  generate-calendar-events:
+    name: Generate Calendar Events
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const fs = require('node:fs/promises');
+
+            const INITIAL_MILESTONE = 64;
+            const major = ${{ github.event.inputs.major }};
+            const milestone = INITIAL_MILESTONE + major*2;
+
+            const events = [['Subject', 'Start Date', 'End Date', 'All Day Event']];
+
+            // Events for the beta milestone
+            {
+              const res = await fetch(`https://chromiumdash.appspot.com/fetch_milestone_schedule?mstone=${milestone - 1}`);
+              const stableDate = new Date((await res.json()).mstones[0].stable_date);
+
+              if (stableDate.getDay() !== 2) {
+                throw new Error(`Expected stable date to be a Tuesday: ${stableDate}`);
+              }
+
+              let date = stableDate.toISOString().split('T')[0];
+              events.push([`${major}.0.0-beta.1 (M${milestone - 1})`, date, date, 'True']);
+
+              const kickOffDate = new Date(stableDate);
+              kickOffDate.setDate(kickOffDate.getDate() - 1);
+              date = kickOffDate.toISOString().split('T')[0];
+              events.push([`Action: Kick Off ${major}.0.0-beta.1`, date, date, 'True']);
+            }
+
+            // Events for the main milestone
+            {
+              const res = await fetch(`https://chromiumdash.appspot.com/fetch_milestone_schedule?mstone=${milestone}`);
+              const stableDate = new Date((await res.json()).mstones[0].stable_date);
+
+              if (stableDate.getDay() !== 2) {
+                throw new Error(`Expected stable date to be a Tuesday: ${stableDate}`);
+              }
+
+              let date = stableDate.toISOString().split('T')[0];
+              events.push([`✨${major}.0.0 Stable✨ (M${milestone})`, date, date, 'True']);
+
+              const kickOffStableDate = new Date(stableDate);
+              kickOffStableDate.setDate(kickOffStableDate.getDate() - 1);
+              date = kickOffStableDate.toISOString().split('T')[0];
+              events.push([`Action: Kick Off ${major}.0.0`, date, date, 'True']);
+
+              const kickOffAlphaDate = new Date(stableDate);
+              kickOffAlphaDate.setDate(kickOffAlphaDate.getDate() + 1);
+              date = kickOffAlphaDate.toISOString().split('T')[0];
+              events.push([`Action: Kick Off ${major + 1}.0.0-alpha.1`, date, date, 'True']);
+
+              const alphaDate = new Date(kickOffAlphaDate);
+              alphaDate.setDate(alphaDate.getDate() + 1);
+              date = alphaDate.toISOString().split('T')[0];
+              events.push([`${major + 1}.0.0-alpha.1`, date, date, 'True']);
+
+              const stableWeekDate = new Date(kickOffStableDate);
+              stableWeekDate.setDate(stableWeekDate.getDate() - 7);
+              const startDate = stableWeekDate.toISOString().split('T')[0];
+              stableWeekDate.setDate(stableWeekDate.getDate() + 5);
+              const endDate = stableWeekDate.toISOString().split('T')[0];
+              events.push(['Stable Prep Week', startDate, endDate, 'True']);
+
+              const stablePrepAssign = new Date(kickOffAlphaDate);
+              stablePrepAssign.setDate(stablePrepAssign.getDate() - 14);
+              date = stablePrepAssign.toISOString().split('T')[0];
+              events.push(['Action: Stable Prep Assignment', date, date, 'True']);
+            }
+
+            await fs.writeFile(`e${major}-calendar-events.csv`, events.flatMap((row) => row.join(',')).join('\n'));
+      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        with:
+          name: Calendar Events E${{ github.event.inputs.major }}
+          path: e${{ github.event.inputs.major }}-calendar-events.csv


### PR DESCRIPTION
This is being migrated from https://github.com/electron/private-workflows/commits/main/.github/workflows/release-calendar-events.yml to this repo so that it can live somewhere public.