### PR TITLE
fix: add 'v' prefix to primary release version on PR lookup

### DIFF
--- a/src/views/pr.handlebars
+++ b/src/views/pr.handlebars
@@ -17,7 +17,7 @@
     <h2 class="grid-header">Release</h2>
     <p class="grid-contents">
       {{#if primary.availableIn}}
-        <a href="/release/{{primary.availableIn.version}}">{{primary.availableIn.version}}</a>
+        <a href="/release/v{{primary.availableIn.version}}">v{{primary.availableIn.version}}</a>
       {{else}}
         This PR has not been released.
       {{/if}}


### PR DESCRIPTION
Refs the functional code further down in the file:

https://github.com/electron/release-status/blob/6718e2627b614fca0bc96f48f9778ba45de8f9ba/src/views/pr.handlebars#L35