### PR TITLE
Gopi kant

### DIFF
--- a/src/routes/release.js
+++ b/src/routes/release.js
@@ -121,8 +121,11 @@ async function handleComparisonRequest(startVersion, endVersion, res) {
     if (parsed.prerelease.length) {
       notes = notes.split(`@${r.tag_name.substr(1)}\`.`)[1];
     }
-    notes =
+    if(notes!=undefined){
+      notes =
       '# Release Notes\n' + notes.replace(/# Release Notes for [^\r\n]+(?:(?:\n)|(?:\r\n))/i, '');
+    }
+    
     return [notes, r.tag_name];
   });
 
@@ -202,9 +205,12 @@ router.get(
     if (parsed.prerelease.length) {
       releaseNotes = releaseNotes.split(new RegExp(`@${escapeRegExp(version.substr(1))}\`?.`))[1];
     }
-    releaseNotes =
+    if(releaseNotes!=undefined){
+      releaseNotes =
       '# Release Notes\n' +
       releaseNotes.replace(/# Release Notes for [^\r\n]+(?:(?:\n)|(?:\r\n))/i, '');
+    }
+    
 
     const lastPreRelease = allReleases.find(
       (r) =>

--- a/src/routes/release.js
+++ b/src/routes/release.js
@@ -121,7 +121,7 @@ async function handleComparisonRequest(startVersion, endVersion, res) {
     if (parsed.prerelease.length) {
       notes = notes.split(`@${r.tag_name.substr(1)}\`.`)[1];
     }
-    if(notes!=undefined){
+    if(notes!==undefined){
       notes =
       '# Release Notes\n' + notes.replace(/# Release Notes for [^\r\n]+(?:(?:\n)|(?:\r\n))/i, '');
     }
@@ -205,7 +205,7 @@ router.get(
     if (parsed.prerelease.length) {
       releaseNotes = releaseNotes.split(new RegExp(`@${escapeRegExp(version.substr(1))}\`?.`))[1];
     }
-    if(releaseNotes!=undefined){
+    if(releaseNotes!==undefined){
       releaseNotes =
       '# Release Notes\n' +
       releaseNotes.replace(/# Release Notes for [^\r\n]+(?:(?:\n)|(?:\r\n))/i, '');


### PR DESCRIPTION
Hi,
In the code, releaseNotes is being split by a regular expression, and the second part (index [1]) is being assigned back to releaseNotes. If the split operation does not result in at least two elements (meaning the regular expression did not match anything), releaseNotes will be undefined, and trying to call replace on it will throw the error.

Bug fixing: Check if releaseNotes is undefined after the split operation
What if the releaseNotes and notes won't be split by a regular expression? What to return in this case?
