### PR TITLE
chore: remove node-fetch usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "1.0.0",
   "main": "src/index.js",
   "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
   "dependencies": {
     "@electron/github-app-auth": "^1.2.0",
     "@octokit/rest": "^18.3.5",
@@ -15,7 +18,6 @@
     "express-paginate": "^1.0.2",
     "jsdom": "^23.0.1",
     "markdown-it": "^12.1.0",
-    "node-fetch": "^2.6.1",
     "p-memoize": "^4.0.1",
     "prismjs": "^1.29.0",
     "semver": "^7.5.2",

--- a/src/data.js
+++ b/src/data.js
@@ -1,5 +1,4 @@
 const { getAuthOptionsForRepo, appCredentialsFromString } = require('@electron/github-app-auth');
-const fetch = require('node-fetch');
 const { Octokit } = require('@octokit/rest');
 const ExpiryMap = require('expiry-map');
 const pMemoize = require('p-memoize');
@@ -34,7 +33,7 @@ const getOctokit = async () => {
 
 const getReleasesOrUpdate = pMemoize(
   async () => {
-    const response = await fetch.default('https://electronjs.org/headers/index.json');
+    const response = await fetch('https://electronjs.org/headers/index.json');
     const releases = await response.json();
     return releases.sort((a, b) => semver.compare(b.version, a.version));
   },
@@ -46,7 +45,7 @@ const getReleasesOrUpdate = pMemoize(
 
 const getActiveReleasesOrUpdate = pMemoize(
   async () => {
-    const response = await fetch.default('https://electron-sudowoodo.herokuapp.com/release/active');
+    const response = await fetch('https://electron-sudowoodo.herokuapp.com/release/active');
     return response.json();
   },
   {
@@ -57,9 +56,7 @@ const getActiveReleasesOrUpdate = pMemoize(
 
 const getAllSudowoodoReleasesOrUpdate = pMemoize(
   async () => {
-    const response = await fetch.default(
-      'https://electron-sudowoodo.herokuapp.com/release/history',
-    );
+    const response = await fetch('https://electron-sudowoodo.herokuapp.com/release/history');
     return response.json();
   },
   {


### PR DESCRIPTION
Should be able to use builtin `fetch`. Sets the minimum Node.js engine as well, to be safe.