### PR TITLE
fix: restore get auth options repo name

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -17,7 +17,10 @@ const getOctokit = async () => {
 
   if (RELEASE_STATUS_GITHUB_APP_CREDS) {
     const authOpts = await getAuthOptionsForRepo(
-      REPO_DATA,
+      {
+        owner: 'electron',
+        name: 'electron',
+      },
       appCredentialsFromString(RELEASE_STATUS_GITHUB_APP_CREDS),
     );
     octokit = new Octokit({


### PR DESCRIPTION
Follow-up to #69 which inadvertently broke authentication. Unfortunately this call site uses `name` for the repo name, rather than `repo` like some other call sites.