### PR TITLE
fix: exclude bot PRs from recent PRs

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -120,7 +120,7 @@ const getRecentPRs = pMemoize(
       });
       return data
         .filter((pr) => {
-          return !pr.user.type !== 'Bot' && pr.merged_at;
+          return pr.user.type !== 'Bot' && pr.merged_at;
         })
         .slice(0, 10);
     } catch {


### PR DESCRIPTION
Follow-up to #69, this extra exclamation mark slipped in during a refactor.