### PR TITLE
Enhance Calendar Layout & Responsiveness in history page

### DIFF
--- a/src/static/css/history.css
+++ b/src/static/css/history.css
@@ -1,5 +1,7 @@
 .container {
-  width: 100%;
+  width: calc(100% - 40px);
+  max-width: 1200px;
+  margin: 0 auto;
 }
 
 .key {
@@ -38,22 +40,40 @@
   flex-wrap: wrap;
   align-items: stretch;
   justify-content: center;
-  flex-direction: row;
+  gap: 20px;
 }
 
 .month {
-  width: 289px;
+  flex: 0 1 100%;
+  max-width: none;
   background-color: white;
   margin: 8px;
-  padding: 15px 15px 20px;
+  padding: 20px;
   display: flex;
   flex-direction: column;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  border-radius: 8px;
+  transition:
+    transform var(--transition-speed) ease,
+    box-shadow var(--transition-speed) ease;
+}
+
+.month:hover {
+  transform: scale(1.02);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
 @media (min-width: 768px) {
   .month {
-    width: 394px;
+    flex: 0 1 calc(50% - 20px);
     padding: 24px 24px 36px;
+  }
+}
+
+@media (min-width: 1024px) {
+  .month {
+    flex: 0 1 calc(33.33% - 40px);
+    padding: 15px;
   }
 }
 
@@ -67,7 +87,8 @@
 
 .month_row.header > h3 {
   font-weight: 700;
-  font-family: 'Arimo', 'CircularPro', 'appleLogo', sans-serif;
+  font-family: var(--font-base);
+  font-size: 1.3rem;
 }
 
 .month_row.header > p {
@@ -95,6 +116,7 @@
   justify-content: center;
   text-decoration: none !important;
   color: inherit !important;
+  transition: background-color 0.3s ease;
 }
 
 .month_day .info {
@@ -110,7 +132,7 @@
   height: 18px;
   width: 18px;
   border-radius: 50%;
-  background-color: #6554c0;
+  background-color: var(--primary-color);
   color: white;
   font-size: 10px;
   display: inline-flex;
@@ -148,17 +170,27 @@
 }
 
 .month_row:not(.day_row) .month_day.has-releases:hover {
-  background-color: #f5f5f5;
+  background-color: var(--hover-bg);
 }
 
 .month_row:not(.day_row) .month_day.no-nightly {
-  background-color: #ff563082;
+  background-color: var(--no-nightly-bg);
+  border-radius: 50%;
 }
 
 .month_row:not(.day_row) .month_day.has-releases.no-nightly:hover {
-  background-color: #ff5630cc;
+  background-color: var(--no-nightly-hover-bg);
 }
 
 .month_day.future {
   opacity: 0.45;
+}
+
+:root {
+  --primary-color: #6554c0;
+  --hover-bg: #eaeaea;
+  --no-nightly-bg: #ff563082;
+  --no-nightly-hover-bg: #ff5630cc;
+  --font-base: 'Arimo', 'CircularPro', 'appleLogo', sans-serif;
+  --transition-speed: 0.3s;
 }


### PR DESCRIPTION
Update .container to use a responsive width with max-width and centered margin.
Increase the gap between calendar items in .calendar.
Add a hover effect to .month with transition properties.
Add a media query for screens wider than 1024px to switch .calendar to a grid layout with three columns.
made Missed Nightly icon square to circular

**Before**

https://github.com/user-attachments/assets/ecc5db04-dcd8-4d87-a29f-a725ecf9bfb0

### After

https://github.com/user-attachments/assets/0a97ce1f-81f2-4e8c-a1bc-eeb265003784




