### PR TITLE
Add Release Schedule Calendar Page with Chromium API Integration and Electron Upcoming Release & Custom Upcoming Event Support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,8 @@ app.use('/release-build', require('./routes/release-build'));
 app.use('/pr', require('./routes/pr'));
 app.use('/pr-lookup', require('./routes/pr-lookup'));
 
+app.use('/schedule', require('./routes/schedule'));
+
 app.use(
   express.static(path.resolve(__dirname, 'static'), {
     fallthrough: true,

--- a/src/routes/schedule.js
+++ b/src/routes/schedule.js
@@ -1,0 +1,28 @@
+const { Router } = require('express');
+
+// const a = require('../utils/a');
+
+const router = new Router();
+
+router.get('/', (req, res) =>
+  res.render('schedule', {
+    css: 'schedule',
+    title: 'Release Schedule',
+  }),
+);
+
+// router.get(
+//   '/:date',
+//   a(async (req, res) => {
+//     const releases = await getReleasesOrUpdate();
+//     const onDate = releases.filter((r) => r.date === req.params.date);
+//     if (onDate.length === 0) return res.redirect('/history');
+//     res.render('date', {
+//       releases: onDate,
+//       css: 'home',
+//       title: req.params.date,
+//     });
+//   }),
+// );
+
+module.exports = router;

--- a/src/static/css/schedule.css
+++ b/src/static/css/schedule.css
@@ -1,0 +1,640 @@
+:root {
+  --electron-blue: #47848f;
+  --electron-dark: #2b2e3b;
+  --electron-light: #9feaf9;
+  --beta-color: #8a6ff8;
+  --stable-color: #00b673;
+  --electron-color: #120145;
+  --hover-transition: all 0.3s ease;
+  --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  --border-radius: 8px;
+}
+
+.schedule {
+  font-family:
+    'Inter',
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
+    Oxygen,
+    Ubuntu,
+    Cantarell,
+    sans-serif;
+  margin: 0;
+  padding: 0;
+  background-color: #f5f7fa;
+  color: #333;
+  transition: background-color 0.3s ease;
+}
+
+.schedule {
+  padding: 16px;
+  max-width: 1400px;
+  margin: 0 auto;
+  box-sizing: border-box;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 24px;
+  gap: 12px;
+  flex-wrap: wrap;
+  text-align: center;
+}
+
+.header h1 {
+  font-size: clamp(20px, 4vw, 28px);
+  font-weight: 600;
+  color: var(--electron-dark);
+  margin: 0;
+}
+
+.header img {
+  height: 40px;
+  animation: pulse 2s infinite alternate;
+}
+
+.key {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  margin-bottom: 24px;
+  padding: 12px;
+  background: white;
+  border-radius: var(--border-radius);
+  box-shadow: var(--card-shadow);
+  flex-wrap: wrap;
+}
+
+.key span {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: #555;
+  font-weight: 500;
+}
+
+.key i {
+  width: 16px;
+  height: 16px;
+  display: inline-block;
+  border-radius: 4px;
+}
+
+.key .beta {
+  background-color: var(--beta-color);
+}
+
+.key .stable {
+  background-color: var(--stable-color);
+}
+.key .electron {
+  background-color: var(--electron-color);
+}
+
+.calendar {
+  background-color: white;
+  border-radius: var(--border-radius);
+  box-shadow: var(--card-shadow);
+  overflow: hidden;
+  opacity: 0;
+  transform: translateY(20px);
+  animation: fadeIn 0.6s ease forwards;
+  width: 100%;
+  min-width: 100%;
+}
+
+.month {
+  margin-bottom: 32px;
+  width: 100%;
+}
+
+.month h2 {
+  text-align: center;
+  color: var(--electron-blue);
+  margin: 20px 0;
+  font-weight: 600;
+  position: relative;
+  padding-bottom: 12px;
+  font-size: clamp(18px, 3vw, 24px);
+}
+
+.month h2::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 60px;
+  height: 3px;
+  background: var(--electron-light);
+  border-radius: 3px;
+}
+
+.days {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  background-color: #f8f9fa;
+  border-radius: var(--border-radius);
+  overflow: hidden;
+  margin: 0 auto;
+  width: 100%;
+  max-width: 100%;
+}
+
+.day-header {
+  background-color: var(--electron-dark);
+  color: white;
+  font-weight: 500;
+  text-align: center;
+  padding: 8px 4px;
+  font-size: clamp(11px, 2vw, 13px);
+  letter-spacing: 0.5px;
+}
+
+.day {
+  background-color: white;
+  padding: 8px 4px;
+  min-height: 60px;
+  border: 1px solid #eaedf0;
+  text-align: right;
+  font-size: clamp(11px, 2vw, 14px);
+  position: relative;
+  transition: var(--hover-transition);
+  box-sizing: border-box;
+  overflow: hidden;
+}
+
+@media (min-width: 768px) {
+  .day {
+    min-width: 150px;
+  }
+}
+
+.day:hover {
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+  transform: translateY(-2px);
+  z-index: 2;
+}
+
+.day .number {
+  position: absolute;
+  top: 4px;
+  right: 6px;
+  font-weight: 500;
+  color: #777;
+  font-size: clamp(10px, 2vw, 13px);
+}
+
+.event {
+  padding: 6px 8px;
+  margin: 6px 2px;
+  font-size: clamp(9px, 1.5vw, 12px);
+  text-align: left;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-weight: 500;
+  transition: var(--hover-transition);
+  cursor: pointer;
+  animation: slideIn 0.3s ease;
+  word-break: break-word;
+}
+
+.event.beta {
+  background-color: rgba(138, 111, 248, 0.1);
+  color: var(--beta-color);
+  border-left: 3px solid var(--beta-color);
+}
+.event.electron {
+  background-color: rgba(32, 23, 66, 0.1);
+  color: var(--electron-color);
+  border-left: 3px solid var(--electron-color);
+}
+
+.event.stable {
+  background-color: rgba(0, 182, 115, 0.1);
+  color: var(--stable-color);
+  border-left: 3px solid var(--stable-color);
+}
+
+.event:hover {
+  transform: translateX(2px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.event.beta i {
+  color: var(--beta-color);
+}
+
+.event.stable i {
+  color: var(--stable-color);
+}
+.event.electron i {
+  color: var(--electron-color);
+}
+
+/* For very small screens, hide icons to save space */
+@media (max-width: 400px) {
+  .event i {
+    display: none;
+  }
+}
+
+#loading,
+#error {
+  text-align: center;
+  color: #777;
+  margin: 32px;
+  font-size: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+
+#loading i {
+  animation: spin 1s linear infinite;
+}
+
+#error {
+  color: #e53935;
+  background-color: rgba(229, 57, 53, 0.1);
+  padding: 16px;
+  border-radius: var(--border-radius);
+}
+
+.today {
+  background-color: rgba(159, 234, 249, 0.2);
+}
+
+.today .number {
+  color: var(--electron-blue);
+  font-weight: 700;
+}
+
+.calendar-controls {
+  margin-bottom: 20px;
+  padding: 12px;
+  background-color: white;
+  border-radius: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+}
+
+.calendar-controls h3 {
+  margin: 0 12px 0 0;
+  padding-right: 12px;
+  color: #555;
+  font-weight: 500;
+  border-right: 1px solid #eee;
+  font-size: clamp(14px, 2.5vw, 16px);
+}
+
+.filter-option {
+  display: flex;
+  align-items: center;
+  padding: 6px 10px;
+  border-radius: 16px;
+  background-color: #f5f5f5;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  margin-right: 6px;
+  margin-bottom: 4px;
+  user-select: none;
+  font-size: clamp(11px, 2vw, 14px);
+}
+
+/* Hide the actual checkbox but keep it in the DOM for functionality */
+.filter-option input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+/* Style for the color indicator */
+.color-swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  display: inline-block;
+  margin-right: 6px;
+  flex-shrink: 0;
+}
+
+/* Active/inactive states */
+.filter-option.active {
+  background-color: rgba(0, 0, 0, 0.05);
+  font-weight: 500;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.filter-option:not(.active) {
+  opacity: 0.6;
+}
+
+.filter-option:hover {
+  background-color: #eee;
+  transform: translateY(-1px);
+}
+
+/* Event modal */
+.event-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1000;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.event-modal-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.event-modal-container {
+  position: relative;
+  background-color: white;
+  border-radius: var(--border-radius);
+  padding: 16px;
+  max-width: 90%;
+  width: 400px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
+  z-index: 1001;
+}
+
+.event-modal-header {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.modal-close-btn {
+  background: none;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+  color: #777;
+}
+
+.event-modal-content h3 {
+  margin-top: 0;
+  color: var(--electron-dark);
+}
+
+/* Animations */
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes slideIn {
+  from {
+    opacity: 0;
+    transform: translateX(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes pulse {
+  from {
+    transform: scale(1);
+  }
+  to {
+    transform: scale(1.1);
+  }
+}
+
+/* Dark mode toggle - just as an example feature */
+.theme-toggle {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  background: var(--electron-dark);
+  color: white;
+  border: none;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: var(--hover-transition);
+  box-shadow: var(--card-shadow);
+  z-index: 100;
+}
+
+.theme-toggle:hover {
+  transform: rotate(30deg);
+  background: var(--electron-blue);
+}
+
+/* Responsive styles - Enhanced */
+@media (max-width: 1024px) {
+  .schedule {
+    padding: 16px 12px;
+  }
+
+  .days {
+    margin: 0 6px;
+  }
+
+  .day {
+    min-height: 80px;
+  }
+}
+
+@media (max-width: 768px) {
+  .day {
+    min-height: 70px;
+    padding: 4px;
+  }
+
+  .event {
+    padding: 4px 6px;
+    margin: 4px 1px;
+  }
+
+  .calendar-controls {
+    padding: 10px;
+    gap: 8px;
+  }
+
+  .calendar-controls h3 {
+    margin-bottom: 6px;
+    padding-right: 0;
+    border-right: none;
+    width: 100%;
+  }
+}
+
+@media (max-width: 600px) {
+  .schedule {
+    padding: 12px 8px;
+  }
+
+  .month {
+    margin-bottom: 24px;
+  }
+
+  .day-header {
+    padding: 6px 2px;
+  }
+
+  .day {
+    min-height: 60px;
+  }
+
+  .day .number {
+    top: 2px;
+    right: 4px;
+  }
+
+  .filter-option {
+    padding: 4px 8px;
+  }
+}
+
+@media (max-width: 480px) {
+  .day {
+    min-height: 50px;
+  }
+
+  .key {
+    gap: 8px;
+    padding: 8px;
+  }
+
+  .key span {
+    font-size: 12px;
+  }
+
+  .event-title {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 100%;
+  }
+}
+
+@media (max-width: 400px) {
+  .days {
+    grid-template-columns: repeat(7, 1fr);
+  }
+
+  .day {
+    min-height: 40px;
+    padding: 2px;
+  }
+
+  .day .number {
+    font-size: 10px;
+  }
+
+  .event {
+    padding: 2px 4px;
+    margin: 2px 0;
+  }
+}
+
+/* Dark mode styles */
+.schedule.dark-mode {
+  background-color: #1e2130;
+  color: #e0e0e0;
+}
+
+.schedule.dark-mode .calendar,
+.schedule.dark-mode .key,
+.schedule.dark-mode .day,
+.schedule.dark-mode .calendar-controls,
+.schedule.dark-mode .event-modal-container {
+  background-color: #2d3142;
+  border-color: #3d4257;
+}
+
+.schedule.dark-mode .day:hover {
+  background-color: #353a4f;
+}
+
+.schedule.dark-mode .day-header {
+  background-color: #242736;
+}
+
+.schedule.dark-mode .number {
+  color: #aaa;
+}
+
+.schedule.dark-mode .header h1 {
+  color: #e0e0e0;
+}
+
+.schedule.dark-mode .event.beta {
+  background-color: rgba(138, 111, 248, 0.2);
+}
+.schedule.dark-mode .event.electron {
+  background-color: rgba(41, 30, 88, 0.2);
+}
+
+.schedule.dark-mode .event.stable {
+  background-color: rgba(0, 182, 115, 0.2);
+}
+
+.schedule.dark-mode .today {
+  background-color: rgba(159, 234, 249, 0.1);
+}
+
+.schedule.dark-mode .theme-toggle {
+  background: var(--electron-light);
+  color: var(--electron-dark);
+}
+
+.schedule.dark-mode .month h2 {
+  color: var(--electron-light);
+}
+
+.schedule.dark-mode .filter-option {
+  background-color: #353a4f;
+}
+
+.schedule.dark-mode .filter-option:hover {
+  background-color: #414561;
+}
+
+.schedule.dark-mode .modal-close-btn {
+  color: #e0e0e0;
+}

--- a/src/static/js/schedule.js
+++ b/src/static/js/schedule.js
@@ -1,0 +1,332 @@
+const apiUrl = 'https://chromiumdash.appspot.com/fetch_milestone_schedule?offset=-1&n=4';
+const weekdays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+// Custom events - Add your events here
+const electronEvents = [
+  { date: '2025-03-20', title: 'Test Stable', type: 'electron', icon: 'fas fa-users' }, // Upcoming electron Relases Can Be Provided Here Or Any Other Events
+];
+
+async function loadCalendar() {
+  const calendarDiv = document.getElementById('calendar');
+  const loadingDiv = document.getElementById('loading');
+  const errorDiv = document.getElementById('error');
+
+  try {
+    // Get the current date to determine which months to display
+    const currentDate = new Date();
+    const monthsToShow = 3; // Number of months to display
+
+    // Fetch API data
+    const response = await fetch(apiUrl);
+    if (!response.ok) throw new Error('Failed to fetch release data');
+    const data = await response.json();
+
+    // Process API events and merge with custom events
+    const events = processEvents(data.mstones);
+
+    // Add custom events to the events object
+    electronEvents.forEach((event) => {
+      if (!events[event.date]) events[event.date] = [];
+      events[event.date].push(event);
+    });
+
+    // Generate month configurations dynamically based on current date
+    const monthsConfig = generateMonthsConfig(currentDate, monthsToShow);
+
+    // Add slight delay for animation effect
+    setTimeout(() => {
+      renderCalendar(monthsConfig, events);
+      loadingDiv.style.display = 'none';
+      errorDiv.style.display = 'none';
+    }, 500);
+  } catch (error) {
+    loadingDiv.style.display = 'none';
+    errorDiv.style.display = 'block';
+    errorDiv.innerHTML = '<i class="fas fa-exclamation-triangle"></i> Error: ' + error.message;
+  }
+}
+
+function generateMonthsConfig(startDate, numMonths) {
+  const months = [];
+
+  for (let i = 0; i < numMonths; i++) {
+    const date = new Date(startDate);
+    date.setMonth(date.getMonth() + i);
+
+    const year = date.getFullYear();
+    const month = date.getMonth();
+
+    // Get month name
+    const monthName = new Date(year, month, 1).toLocaleString('default', { month: 'long' });
+
+    // Calculate days in month
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
+
+    // Calculate start day (0 = Sunday, 1 = Monday, etc.)
+    const firstDay = new Date(year, month, 1).getDay();
+
+    months.push({
+      name: `${monthName} ${year}`,
+      days: daysInMonth,
+      startDay: firstDay,
+      year: year,
+      month: month + 1, // JavaScript months are 0-indexed, but we need 1-indexed for formatting
+    });
+  }
+
+  return months;
+}
+
+function processEvents(mstones) {
+  const events = {};
+  mstones.forEach((m) => {
+    const milestone = `${m.mstone}`;
+    addEvent(events, m.earliest_beta, `M${milestone} Early Beta`, 'beta', 'fas fa-flask');
+    addEvent(events, m.final_beta, `M${milestone} Final Beta`, 'beta', 'fas fa-vial');
+    addEvent(events, m.stable_date, `M${milestone} Stable`, 'stable', 'fas fa-rocket');
+  });
+  return events;
+}
+
+function addEvent(events, dateStr, title, type, icon) {
+  if (!dateStr) return;
+  const date = new Date(dateStr).toISOString().split('T')[0];
+  if (!events[date]) events[date] = [];
+  events[date].push({ title, type, icon });
+}
+
+function renderCalendar(monthsConfig, events) {
+  const calendarDiv = document.getElementById('calendar');
+  calendarDiv.innerHTML = ''; // Clear loading/error
+
+  // Get today's date for highlighting
+  const today = new Date();
+  const todayString = today.toISOString().split('T')[0];
+
+  // Create controls for filtering
+  const controlsDiv = document.createElement('div');
+  controlsDiv.className = 'calendar-controls';
+
+  const filterHeading = document.createElement('h3');
+  filterHeading.className = 'filter-heading';
+  filterHeading.innerHTML = '<i class="fa fa-filter" aria-hidden="true"></i>Filter';
+  controlsDiv.appendChild(filterHeading);
+
+  const eventTypes = ['beta', 'stable', 'electron'];
+  const eventColors = {
+    beta: 'var(--beta-color)',
+    stable: 'var(--stable-color)',
+    electron: 'var(--electron-color)',
+  };
+
+  eventTypes.forEach((type) => {
+    const filterOption = document.createElement('div');
+    filterOption.className = 'filter-option active'; // Start as active
+    filterOption.dataset.eventType = type;
+
+    const colorSwatch = document.createElement('span');
+    colorSwatch.className = 'color-swatch';
+    colorSwatch.style.backgroundColor = eventColors[type];
+
+    const labelText = document.createElement('span');
+    labelText.textContent = type.charAt(0).toUpperCase() + type.slice(1);
+
+    filterOption.appendChild(colorSwatch);
+    filterOption.appendChild(labelText);
+
+    // Toggle active class and filter events on click
+    filterOption.addEventListener('click', () => {
+      filterOption.classList.toggle('active');
+      filterEvents();
+    });
+
+    controlsDiv.appendChild(filterOption);
+  });
+
+  // Modify the filterEvents function to check for active class
+  function filterEvents() {
+    const activeFilters = Array.from(document.querySelectorAll('.filter-option.active')).map(
+      (el) => el.dataset.eventType,
+    );
+
+    document.querySelectorAll('.event').forEach((event) => {
+      const eventType = event.classList.contains('beta')
+        ? 'beta'
+        : event.classList.contains('stable')
+          ? 'stable'
+          : 'electron';
+
+      if (activeFilters.includes(eventType)) {
+        event.style.display = '';
+      } else {
+        event.style.display = 'none';
+      }
+    });
+  }
+
+  calendarDiv.appendChild(controlsDiv);
+
+  monthsConfig.forEach((month, monthIndex) => {
+    const monthDiv = document.createElement('div');
+    monthDiv.className = 'month';
+    monthDiv.style.animationDelay = monthIndex * 0.2 + 's';
+    monthDiv.innerHTML = `<h2>${month.name}</h2>`;
+
+    const daysDiv = document.createElement('div');
+    daysDiv.className = 'days';
+
+    // Weekday headers
+    weekdays.forEach((day) => {
+      const header = document.createElement('div');
+      header.className = 'day-header';
+      header.textContent = day;
+      daysDiv.appendChild(header);
+    });
+
+    // Empty days before the 1st
+    for (let i = 0; i < month.startDay; i++) {
+      const emptyDay = document.createElement('div');
+      emptyDay.className = 'day empty';
+      daysDiv.appendChild(emptyDay);
+    }
+
+    // Days of the month
+    for (let day = 1; day <= month.days; day++) {
+      const monthNum = month.month.toString().padStart(2, '0');
+      const date = `${month.year}-${monthNum}-${day.toString().padStart(2, '0')}`;
+
+      const dayDiv = document.createElement('div');
+      dayDiv.className = 'day';
+      dayDiv.dataset.date = date;
+
+      // Check if this is today
+      if (date === todayString) {
+        dayDiv.classList.add('today');
+      }
+
+      const numberSpan = document.createElement('span');
+      numberSpan.className = 'number';
+      numberSpan.textContent = day;
+      dayDiv.appendChild(numberSpan);
+
+      const dayEvents = events[date] || [];
+      dayEvents.forEach((event, idx) => {
+        const eventDiv = document.createElement('div');
+        eventDiv.className = `event ${event.type}`;
+        eventDiv.dataset.eventType = event.type;
+        eventDiv.style.animationDelay = idx * 0.1 + 's';
+
+        eventDiv.innerHTML = `
+          <i class="${event.icon}" aria-hidden="true"></i>
+          <span class="event-title">${event.title}</span>
+        `;
+
+        // Add click event for interaction
+        eventDiv.addEventListener('click', () => {
+          showEventDetails(event, date);
+        });
+
+        dayDiv.appendChild(eventDiv);
+      });
+
+      daysDiv.appendChild(dayDiv);
+    }
+
+    monthDiv.appendChild(daysDiv);
+    calendarDiv.appendChild(monthDiv);
+  });
+}
+
+function showEventDetails(event, date) {
+  const formattedDate = new Date(date).toLocaleDateString(undefined, {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+
+  const modalContent = `
+    <div class="event-modal-content">
+      <h3><i class="${event.icon}"></i> ${event.title}</h3>
+      <p>Date: ${formattedDate}</p>
+      <p>Type: ${event.type.charAt(0).toUpperCase() + event.type.slice(1)}</p>
+      ${event.description ? `<p>${event.description}</p>` : ''}
+    </div>
+  `;
+
+  // Create a simple modal
+  const modal = document.createElement('div');
+  modal.className = 'event-modal';
+  modal.innerHTML = `
+    <div class="event-modal-overlay"></div>
+    <div class="event-modal-container">
+      <div class="event-modal-header">
+        <button class="modal-close-btn">&times;</button>
+      </div>
+      ${modalContent}
+    </div>
+  `;
+
+  document.body.appendChild(modal);
+
+  // Close modal when clicking close button or overlay
+  modal.querySelector('.modal-close-btn').addEventListener('click', () => {
+    document.body.removeChild(modal);
+  });
+
+  modal.querySelector('.event-modal-overlay').addEventListener('click', () => {
+    document.body.removeChild(modal);
+  });
+}
+
+function filterEvents() {
+  const checkboxes = document.querySelectorAll('.filter-option input');
+  const visibleTypes = Array.from(checkboxes)
+    .filter((checkbox) => checkbox.checked)
+    .map((checkbox) => checkbox.dataset.eventType);
+
+  const events = document.querySelectorAll('.event');
+  events.forEach((event) => {
+    if (visibleTypes.includes(event.dataset.eventType)) {
+      event.style.display = 'flex';
+    } else {
+      event.style.display = 'none';
+    }
+  });
+}
+
+// Add tooltip functionality
+function addTooltips() {
+  const events = document.querySelectorAll('.event');
+  events.forEach((event) => {
+    const title = event.querySelector('.event-title').textContent;
+    event.setAttribute('title', title);
+  });
+}
+
+// Add animation when scrolling
+function addScrollAnimation() {
+  const months = document.querySelectorAll('.month');
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.style.animationPlayState = 'running';
+        }
+      });
+    },
+    { threshold: 0.1 },
+  );
+
+  months.forEach((month) => {
+    month.style.animationPlayState = 'paused';
+    observer.observe(month);
+  });
+}
+
+// Start loading the calendar
+loadCalendar().then(() => {
+  addTooltips();
+  addScrollAnimation();
+});

--- a/src/views/layouts/main.handlebars
+++ b/src/views/layouts/main.handlebars
@@ -1,32 +1,32 @@
-<!DOCTYPE html>
-<html lang="en">
+<html lang='en'>
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta charset='UTF-8' />
+    <meta name='viewport' content='width=device-width, initial-scale=1.0' />
     <title>Electron Releases</title>
+    <link rel='shortcut icon' href='https://www.electronjs.org/images/favicon.ico' />
     <link
-      rel="shortcut icon"
-      href="https://www.electronjs.org/images/favicon.ico"
+      href='https://fonts.googleapis.com/css2?family=Arimo:wght@700&display=swap'
+      rel='stylesheet'
     />
-    <link href="https://fonts.googleapis.com/css2?family=Arimo:wght@700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/css/styles.css" type="text/css" />
+    <link rel='stylesheet' href='/css/styles.css' type='text/css' />
     {{#if css}}
-    <link rel="stylesheet" href="/css/{{css}}.css" type="text/css" />
+      <link rel='stylesheet' href='/css/{{css}}.css' type='text/css' />
     {{/if}}
-    <script src="https://kit.fontawesome.com/8fb0264ba9.js" crossorigin="anonymous"></script>
+    <script src='https://kit.fontawesome.com/8fb0264ba9.js' crossorigin='anonymous'></script>
   </head>
   <body>
-    <nav class="navbar">
+    <nav class='navbar'>
       <div>
-        <a href="/">
-          <img src="https://www.electronjs.org/assets/img/logo.svg" />
-          <span class="title">Electron Releases</span>
+        <a href='/'>
+          <img src='https://www.electronjs.org/assets/img/logo.svg' />
+          <span class='title'>Electron Releases</span>
         </a>
         <div>
-          <a href="/releases">All Releases</a>
-          <a href="/history">History</a>
-          <a href="/pr-lookup">PR Lookup</a>
-          <a href="https://electronjs.org" target="_blank" rel="noopener noreferrer">Website</a>
+          <a href='/releases'>All Releases</a>
+          <a href='/schedule'>Schedule</a>
+          <a href='/history'>History</a>
+          <a href='/pr-lookup'>PR Lookup</a>
+          <a href='https://electronjs.org' target='_blank' rel='noopener noreferrer'>Website</a>
         </div>
       </div>
     </nav>
@@ -36,39 +36,45 @@
           Electron Releases
           {{#if title}} - {{{title}}}{{/if}}
           {{#if compareList}}
-          <div class="version-select-wrapper">
-            <select class="version-select" onchange="goToCompare()">
-              <option disabled selected>Compare To:</option>
-              {{#each compareList}}
-              <option>v{{this}}</option>
-              {{/each}}
-            </select>
-          </div>
+            <div class='version-select-wrapper'>
+              <select class='version-select' onchange='goToCompare()'>
+                <option disabled selected>Compare To:</option>
+                {{#each compareList}}
+                  <option>v{{this}}</option>
+                {{/each}}
+              </select>
+            </div>
           {{/if}}
         </h1>
       </div>
     </header>
     <main>
       <div>
-        {{{ body }}}
+        {{{body}}}
       </div>
     </main>
     <footer>
-      <div style="display: flex; justify-content: center; align-items: center; flex-direction: column;">
-          <ul style="list-style: none; padding-left: 0; text-align: center;">
-            <li style="display: inline-block;"><a href="https://bsky.app/profile/electronjs.org" rel="noopener noreferrer">Bluesky</a></li>
-            <li style="display: inline-block;"><a href="https://github.com/electron/electron" rel="noopener noreferrer">Repository</a></li>
-          </ul>
-          <div>
-            <p>Provided with&nbsp;❤️&nbsp;by Electron</p>
-          </div>
+      <div
+        style='display: flex; justify-content: center; align-items: center; flex-direction: column;'
+      >
+        <ul style='list-style: none; padding-left: 0; text-align: center;'>
+          <li style='display: inline-block;'><a
+              href='https://bsky.app/profile/electronjs.org'
+              rel='noopener noreferrer'
+            >Bluesky</a></li>
+          <li style='display: inline-block;'><a
+              href='https://github.com/electron/electron'
+              rel='noopener noreferrer'
+            >Repository</a></li>
+        </ul>
+        <div>
+          <p>Provided with&nbsp;❤️&nbsp;by Electron</p>
+        </div>
       </div>
     </footer>
     <script>
-      function goToCompare() {
-        const elem = document.querySelector('.version-select');
-        window.location.href = `/release/compare/{{ compareTarget }}/${elem.value}`;
-      }
+      function goToCompare() { const elem = document.querySelector('.version-select');
+      window.location.href = `/release/compare/{{compareTarget}}/${elem.value}`; }
     </script>
   </body>
 </html>

--- a/src/views/schedule.handlebars
+++ b/src/views/schedule.handlebars
@@ -1,0 +1,19 @@
+<div class='container schedule'>
+
+  <div class='key'>
+    <span><i class='electron'></i>Electron Release</span>
+    <span><i class='beta'></i> Chromium Beta</span>
+    <span><i class='stable'></i>Chromium Stable</span>
+  </div>
+
+  <div id='loading'>
+    <i class='fas fa-spinner'></i>
+    Loading release schedule...
+  </div>
+
+  <div id='error' style='display: none;'></div>
+
+  <div id='calendar' class='calendar'></div>
+</div>
+
+<script src='/js/schedule.js'></script>


### PR DESCRIPTION
Introducing <h1>Release Schedule Calendar Page</h1> Which dynamically fetches Chromium release dates via API and integrates Electron’s upcoming releases and custom events. The goal is to improve visibility into upcoming stable, beta, and alpha releases, reducing manual updates while keeping the Electron team informed.

<img width="1085" alt="Screenshot 2025-03-07 at 5 52 05 AM" src="https://github.com/user-attachments/assets/8314f1ea-9206-4e1c-b13a-d1a61becece9" />


Key Features 🚀

✅ Chromium API Integration: Automatically fetches release dates (Stable, Beta, Early Beta) from Chromium’s API.
✅ Electron Release Support: Displays Electron’s upcoming releases alongside Chromium’s timeline.
✅ Custom Event Support: Users can add additional important dates for internal tracking.
✅ Interactive UI:

- 	Clean calendar layout with color-coded release types.
- 	Filter option to toggle between Beta, Stable, and Electron releases.
- 	Responsive 3-column calendar view on large screens and optimized for smaller screens.

✅ Automated Updates:

- Fetches the latest Chromium release schedule without manual intervention.


Future Enhancements 🌟

- 	Automating Electron’s internal release updates via GitHub actions or a bot.
- 	Adding more granular filters for specific release versions.
- 	Enhancing event descriptions with additional metadata.

This Enhancement is releted to the GSOC 2025 Idea list by electron.

Dear Mentors,
Plese review if it fulfills the requirements.
@dsanders11  @VerteDinde @yangannyx 

