### PR TITLE
Enhanced getPRReleaseStatus to handle alpha and beta releases (pr.js)

### DIFF
--- a/src/routes/pr.js
+++ b/src/routes/pr.js
@@ -38,7 +38,7 @@ async function getPRReleaseStatus(prNumber) {
     const backports = [];
     let availableIn = null;
 
-    // We've been merged, let's find out if this is available in a nightly
+    // We've been merged, now checking which release version includes this PR
     if (merged) {
       const allReleases = releases.filter(
         (r) =>

--- a/src/routes/pr.js
+++ b/src/routes/pr.js
@@ -40,16 +40,19 @@ async function getPRReleaseStatus(prNumber) {
 
     // We've been merged, let's find out if this is available in a nightly
     if (merged) {
-      const allNightlies = releases.filter(
-        (r) => semver.parse(r.version).prerelease[0] === 'nightly',
+      const allReleases = releases.filter(
+        (r) =>
+          semver.parse(r.version).prerelease[0] === 'nightly' ||
+          semver.parse(r.version).prerelease[0] === 'alpha' ||
+          semver.parse(r.version).prerelease[0] === 'beta',
       );
-      for (const nightly of allNightlies) {
-        const dateParts = nightly.date.split('-').map((n) => parseInt(n, 10));
+      for (const release of allReleases) {
+        const dateParts = release.date.split('-').map((n) => parseInt(n, 10));
         const releaseDate = new Date(dateParts[0], dateParts[1] - 1, dateParts[2] + 1);
         if (releaseDate > new Date(merged_at)) {
-          const comparison = await compareTagToCommit(`v${nightly.version}`, merge_commit_sha);
+          const comparison = await compareTagToCommit(`v${release.version}`, merge_commit_sha);
           if (comparison.status === 'behind') {
-            availableIn = nightly;
+            availableIn = release;
             break;
           }
         }


### PR DESCRIPTION
## What does this PR do?
This PR enhances the **getPRReleaseStatus** function in **src/routes/pr.js** to include checks for alpha and beta releases. Previously, the function only considered nightly releases.

Fixes #30 

Before

![Screenshot 2025-03-15 at 16-51-07 Electron Releases](https://github.com/user-attachments/assets/959c9329-cf64-42cd-90ee-683cb9c3fb9c)

After

![Screenshot 2025-03-15 at 16-50-47 Electron Releases](https://github.com/user-attachments/assets/9784fdf3-599d-49db-ace2-330dafe9e203)
