### PR TITLE
fix: shortcut-icon url in header

### DIFF
--- a/src/views/layouts/main.handlebars
+++ b/src/views/layouts/main.handlebars
@@ -6,7 +6,7 @@
     <title>Electron Releases</title>
     <link
       rel="shortcut icon"
-      href="https://www.electronjs.org/images/favicon.ico"
+      href="https://www.electronjs.org/assets/img/favicon.ico"
     />
     <link href="https://fonts.googleapis.com/css2?family=Arimo:wght@700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/css/styles.css" type="text/css" />


### PR DESCRIPTION
This PR Fixes: #94 (invalid shortcut-url in header).
Updated the favicon.ico to new url from electron official website