### PR TITLE
fix: correct favicon URL

### DIFF
--- a/src/views/layouts/main.handlebars
+++ b/src/views/layouts/main.handlebars
@@ -6,7 +6,7 @@
     <title>Electron Releases</title>
     <link
       rel="shortcut icon"
-      href="https://www.electronjs.org/images/favicon.ico"
+      href="https://www.electronjs.org/assets/img/favicon.ico"
     />
     <link href="https://fonts.googleapis.com/css2?family=Arimo:wght@700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/css/styles.css" type="text/css" />


### PR DESCRIPTION
This PR Fixes: https://github.com/electron/release-status/issues/94 (invalid shortcut-url in header).
Updated the favicon.ico to new url from electron official website

I have closed previous PR, due to some disturbance it was making on my side.