### PR TITLE
fix: handle 0.x version selection

### DIFF
--- a/src/routes/releases.js
+++ b/src/routes/releases.js
@@ -87,7 +87,7 @@ router.get(
       return acc;
     }, new Set());
     const releasesFromMajor = releasesFromChannel.filter((release) => {
-      if (major) {
+      if (major != null) {
         return semver.major(release.version) === major;
       } else {
         return true;

--- a/src/routes/releases.js
+++ b/src/routes/releases.js
@@ -87,7 +87,7 @@ router.get(
       return acc;
     }, new Set());
     const releasesFromMajor = releasesFromChannel.filter((release) => {
-      if (major != null) {
+      if (major !== null) {
         return semver.major(release.version) === major;
       } else {
         return true;


### PR DESCRIPTION
#### Description of Change
This PR Fixes: #97 (wrong display of versions on releases page)
updated the condition to handle 0 value for major, which was being treated as false value.

#### Checklist
<!-- Please confirm the following by changing [ ] to [x]. -->

- [x] This PR was not created with AI. (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.)