### PR TITLE
fix: mobile responsiveness for PR Lookup table with horizontal scrolling

### DIFF
--- a/src/static/css/pr-lookup.css
+++ b/src/static/css/pr-lookup.css
@@ -35,6 +35,22 @@
   display: none;
 }
 
+/* Add container style for table */
+.table-container {
+  width: 100%;
+  max-width: 100%;
+  overflow: hidden; /* Prevent container from scrolling */
+  margin-top: 20px;
+  margin-bottom: 20px;
+  position: relative; /* For proper containment */
+}
+
+/* Mobile-responsive container style */
+.mobile-responsive {
+  width: 100%;
+  max-width: 100%;
+}
+
 h1 {
   text-align: center;
   color: #3b4a6b;
@@ -80,6 +96,7 @@ td {
   text-align: left;
   padding: 12px;
   border-bottom: 1px solid #ddd;
+  white-space: nowrap;
 }
 
 th {
@@ -99,8 +116,172 @@ td a:hover {
 
 tr:hover {
   background-color: #f9fafc;
+  cursor: pointer;
 }
 
 tr:last-child td {
   border-bottom: none;
+}
+
+/* Add styles for PR title and author */
+.pr-title {
+  max-width: 400px;
+  overflow: visible;
+  white-space: nowrap;
+}
+
+.pr-author {
+  max-width: 150px;
+  overflow: visible;
+  white-space: nowrap;
+}
+
+/* Mobile container style */
+.mobile-container {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0 16px;
+}
+
+/* Responsive styles for mobile */
+@media screen and (max-width: 767px) {
+  /* Overall container */
+  .mobile-container {
+    padding: 0;
+    overflow-x: hidden;
+    width: 100%;
+  }
+
+  /* Remove padding from main content area entirely */
+  main > div {
+    padding: 0 !important;
+    width: 100% !important;
+    box-sizing: border-box !important;
+    overflow-x: hidden !important; /* Prevent whole page scrolling */
+  }
+
+  /* Table input and error */
+  .lookup-input {
+    padding: 0 8px;
+  }
+
+  .error {
+    padding: 0 8px;
+  }
+
+  /* Container for the table */
+  .table-container {
+    padding: 0;
+    margin: 0;
+    width: 100%;
+    max-width: 100vw; /* Use viewport width to ensure it doesn't exceed screen */
+    overflow-x: hidden; /* Hide overflow on the container */
+    position: relative;
+  }
+
+  .mobile-responsive {
+    width: 100%;
+    max-width: 100%;
+    overflow-x: auto; /* Only the inner container scrolls */
+    -webkit-overflow-scrolling: touch;
+    margin: 0;
+    padding: 0 8px; /* Add some padding to ensure first column is fully visible */
+    box-sizing: border-box;
+    /* Show that it's scrollable with a simple indicator */
+    scrollbar-width: thin;
+    scrollbar-color: rgba(59, 74, 107, 0.5) transparent;
+  }
+
+  /* Webkit scrollbar styling */
+  .mobile-responsive::-webkit-scrollbar {
+    height: 6px;
+  }
+
+  .mobile-responsive::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .mobile-responsive::-webkit-scrollbar-thumb {
+    background-color: rgba(59, 74, 107, 0.5);
+    border-radius: 6px;
+  }
+
+  /* Ensure table is sized properly for scrolling */
+  .mobile-responsive table {
+    width: auto;
+    min-width: 450px; /* 50px + 220px + 80px + 100px */
+    border-collapse: collapse;
+    border-spacing: 0;
+    margin: 0;
+    table-layout: fixed; /* Ensure consistent column widths */
+  }
+
+  /* Make the table headers sticky */
+  .mobile-responsive th {
+    position: sticky;
+    top: 0;
+    background-color: #f2f4f7;
+    z-index: 2;
+    font-size: 14px;
+  }
+
+  /* Adjust font size for mobile */
+  .mobile-responsive td,
+  .mobile-responsive th {
+    padding: 8px 6px;
+    font-size: 14px;
+    overflow: visible;
+    white-space: nowrap;
+  }
+
+  /* Add scrolling indicator */
+  .mobile-responsive:after {
+    content: '';
+    position: absolute;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    width: 30px;
+    background: linear-gradient(to right, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.7));
+    pointer-events: none;
+    z-index: 3;
+  }
+
+  /* Better column widths for mobile */
+  th:nth-child(1),
+  td:nth-child(1) {
+    width: 50px;
+    min-width: 50px;
+  }
+
+  th:nth-child(2),
+  td:nth-child(2) {
+    width: 220px;
+    min-width: 220px;
+  }
+
+  th:nth-child(3),
+  td:nth-child(3) {
+    width: 80px;
+    min-width: 80px;
+  }
+
+  th:nth-child(4),
+  td:nth-child(4) {
+    width: 100px;
+    min-width: 100px;
+  }
+
+  /* Cell-specific styles */
+  .mobile-responsive .pr-title {
+    max-width: 220px;
+    overflow: visible;
+    white-space: nowrap;
+  }
+
+  .mobile-responsive .pr-author {
+    max-width: 80px;
+    overflow: visible;
+    white-space: nowrap;
+  }
 }

--- a/src/views/pr-lookup.handlebars
+++ b/src/views/pr-lookup.handlebars
@@ -1,4 +1,4 @@
-<div>
+<div class="mobile-container">
 <div class="lookup-input">
   <form onsubmit="lookup(event)">
     <input id="input" type="text" placeholder="12345" required>
@@ -6,22 +6,24 @@
   </form>
 </div>
 <p class="error" id="error"></p>
-<div class="recent-prs">
-  <table>
-    <thead>
-      <tr>
-        <th>PR Number</th>
-        <th>Title</th>
-        <th>Author</th>
-        <th>Date</th>
-      </tr>
-    </thead>
-    <tbody id="table-body">
-      {{#each recentPRs}}
-      {{> recentPR this}}
-      {{/each}}
-    </tbody>
-  </table>
+<div class="table-container">
+  <div class="mobile-responsive">
+    <table>
+      <thead>
+        <tr>
+          <th>PR Number</th>
+          <th>Title</th>
+          <th>Author</th>
+          <th>Date</th>
+        </tr>
+      </thead>
+      <tbody id="table-body">
+        {{#each recentPRs}}
+        {{> recentPR this}}
+        {{/each}}
+      </tbody>
+    </table>
+  </div>
 </div>
 </div>
 


### PR DESCRIPTION
## Issue
On the Electron Releases PR Lookup page, the titles and author names in the PR table were not fully visible on mobile devices. The content was being cut off, resulting in a poor user experience.

## Changes
This PR implements horizontal scrolling for the PR table on mobile devices, with the following improvements:

- Added proper container structure with `table-container` and `mobile-responsive` classes
- Implemented horizontal scrolling that's constrained to just the table area (not the whole page)
- Ensured all column content is fully visible through horizontal scrolling
- Added subtle scrollbar styling and visual indicators for better usability
- Adjusted column widths and padding for optimal mobile display
- Prevented text truncation with ellipsis, allowing full content visibility
- Made table headers sticky for better navigation


## Testing
Tested on various mobile device sizes to ensure proper display and horizontal scrolling functionality.

Fixes #102
