### PR TITLE
Fixed release issue #30

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -48,6 +48,18 @@ const getReleasesOrUpdate = pMemoize(
   },
 );
 
+const getReleasesOrUpdateSortedByDate = pMemoize(
+  async () => {
+    const response = await fetch('https://electronjs.org/headers/index.json');
+    const releases = await response.json();
+    return releases.sort((a, b) => new Date(a.date) - new Date(b.date)); // sort data from oldest to newest
+  },
+  {
+    cache: new ExpiryMap(60 * 1000),
+    cacheKey: () => 'releases',
+  },
+);
+
 const getDownloadStatsOrUpdate = pMemoize(
   async () => {
     const response = await fetch('https://electron-sudowoodo.herokuapp.com/release/active');
@@ -209,6 +221,7 @@ const getTSDefs = pMemoize(
 module.exports = {
   getGitHubRelease,
   getReleasesOrUpdate,
+  getReleasesOrUpdateSortedByDate,
   getActiveReleasesOrUpdate,
   getAllSudowoodoReleasesOrUpdate,
   getPR,


### PR DESCRIPTION
#### Description of Change

<!-- Thank you for your Pull Request. Please describe your change here. -->
Fixed the issue: Release logic misses case where first release was an alpha #30, by doing:

-  **New Function**: Added getReleasesOrUpdateSortedByDate to sort releases by date from oldest to newest.
-  **Usage**: used the new function in src/routes/pr.js to fetch releases, instead of the old one which was sorting alphabetically.
-  **Logic Changes**:  Changed the filtration from choosing nightlies only to focusing on non-nightly prereleases (alpha, beta).
-  **Refactoring**: Updated variable names and comments for clarity and readability.


#### Checklist
<!-- Please confirm the following by changing [ ] to [x]. -->

- [x] This PR was not created with AI. (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.)
- [x] PR description included and stakeholders cc'd
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).
