### PR TITLE
Fix: releases issue #30

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -52,11 +52,11 @@ const getReleasesOrUpdateSortedByDate = pMemoize(
   async () => {
     const response = await fetch('https://electronjs.org/headers/index.json');
     const releases = await response.json();
-    return releases.sort((a, b) => new Date(a.date) - new Date(b.date)); // sort data from oldest to newest
+    return releases.sort((a, b) => new Date(a.date) - new Date(b.date));
   },
   {
     cache: new ExpiryMap(60 * 1000),
-    cacheKey: () => 'releases_by_date',
+    cacheKey: () => 'releases_sorted_by_date',
   },
 );
 

--- a/src/data.js
+++ b/src/data.js
@@ -56,7 +56,7 @@ const getReleasesOrUpdateSortedByDate = pMemoize(
   },
   {
     cache: new ExpiryMap(60 * 1000),
-    cacheKey: () => 'releases',
+    cacheKey: () => 'releases_by_date',
   },
 );
 

--- a/src/data.js
+++ b/src/data.js
@@ -48,6 +48,18 @@ const getReleasesOrUpdate = pMemoize(
   },
 );
 
+const getReleasesOrUpdateSortedByDate = pMemoize(
+  async () => {
+    const response = await fetch('https://electronjs.org/headers/index.json');
+    const releases = await response.json();
+    return releases.sort((a, b) => new Date(a.date) - new Date(b.date)); // sort data from oldest to newest
+  },
+  {
+    cache: new ExpiryMap(60 * 1000),
+    cacheKey: () => 'releases',
+  },
+);
+
 const getDownloadStatsOrUpdate = pMemoize(
   async () => {
     const response = await fetch('https://electron-sudowoodo.herokuapp.com/release/active');
@@ -209,6 +221,7 @@ const getTSDefs = pMemoize(
 module.exports = {
   getGitHubRelease,
   getReleasesOrUpdate,
+  getReleasesOrUpdateSortedByDate,
   getActiveReleasesOrUpdate,
   getAllSudowoodoReleasesOrUpdate,
   getPR,

--- a/src/routes/pr.js
+++ b/src/routes/pr.js
@@ -18,8 +18,8 @@ Handlebars.registerHelper('html', (content) => DOMPurify.sanitize(content));
 
 async function getPRReleaseStatus(prNumber) {
   const releases = await getReleasesOrUpdateSortedByDate();
-  const [prInfo, comments] = await Promise.all([getPR(prNumber), getPRComments(prNumber)]); // get PR info
-  if (!prInfo) return null; // if the PR is not found, return null
+  const [prInfo, comments] = await Promise.all([getPR(prNumber), getPRComments(prNumber)]);
+  if (!prInfo) return null;
 
   const { base, merged, merged_at, merge_commit_sha } = prInfo;
 
@@ -41,7 +41,7 @@ async function getPRReleaseStatus(prNumber) {
     if (merged) {
       const allPrereleases = releases.filter((r) => { // non-nightly prereleases
         let releaseTag = semver.parse(r.version).prerelease[0];
-        return releaseTag !== 'nightly' && releaseTag !== undefined; // filter out non-nightly releases and not stable releases
+        return releaseTag !== 'nightly' && releaseTag !== undefined; // filter out nightly and stable releases
       });
       for (const prerelease of allPrereleases) {
         const dateParts = prerelease.date.split('-').map((n) => parseInt(n, 10));

--- a/src/routes/pr.js
+++ b/src/routes/pr.js
@@ -8,7 +8,7 @@ const window = new JSDOM('').window;
 const DOMPurify = createDOMPurify(window);
 
 const a = require('../utils/a');
-const { compareTagToCommit, getReleasesOrUpdate, getPR, getPRComments, getReleasesOrUpdateSortedByDate } = require('../data');
+const { compareTagToCommit, getPR, getPRComments, getReleasesOrUpdateSortedByDate } = require('../data');
 
 const router = new Router();
 

--- a/src/routes/pr.js
+++ b/src/routes/pr.js
@@ -8,13 +8,7 @@ const window = new JSDOM('').window;
 const DOMPurify = createDOMPurify(window);
 
 const a = require('../utils/a');
-const {
-  compareTagToCommit,
-  getReleasesOrUpdate,
-  getPR,
-  getPRComments,
-  getReleasesOrUpdateSortedByDate,
-} = require('../data');
+const { compareTagToCommit, getReleasesOrUpdate, getPR, getPRComments, getReleasesOrUpdateSortedByDate } = require('../data');
 
 const router = new Router();
 
@@ -45,8 +39,7 @@ async function getPRReleaseStatus(prNumber) {
 
     // We've been merged
     if (merged) {
-      // non-nightly prereleases
-      const allPrereleases = releases.filter((r) => {
+      const allPrereleases = releases.filter((r) => { // non-nightly prereleases
         let releaseTag = semver.parse(r.version).prerelease[0];
         return releaseTag !== 'nightly' && releaseTag !== undefined; // filter out non-nightly releases and not stable releases
       });
@@ -174,12 +167,11 @@ router.get(
   '/:number',
   a(async (req, res) => {
     const prNumber = parseInt(req.params.number, 10);
-    if (isNaN(prNumber) || prNumber < 0) return res.redirect('/'); // if the number is invalid, redirect to home
-    const prInfo = await getPRReleaseStatus(prNumber); // get PR info and release status
-    if (!prInfo) return res.redirect('/'); // if the PR is not found, redirect to home
+    if (isNaN(prNumber) || prNumber < 0) return res.redirect('/');
+    const prInfo = await getPRReleaseStatus(prNumber);
+    if (!prInfo) return res.redirect('/');
 
     res.render('pr', {
-      // render the PR page with the PR info
       ...prInfo,
       css: 'pr',
       title: `PR #${prNumber} - Release Status`,

--- a/src/routes/pr.js
+++ b/src/routes/pr.js
@@ -8,7 +8,7 @@ const window = new JSDOM('').window;
 const DOMPurify = createDOMPurify(window);
 
 const a = require('../utils/a');
-const { compareTagToCommit, getPR, getPRComments, getReleasesOrUpdateSortedByDate } = require('../data');
+const { compareTagToCommit, getPR, getPRComments, getReleasesOrUpdateSortedByDate} = require('../data');
 
 const router = new Router();
 
@@ -39,9 +39,9 @@ async function getPRReleaseStatus(prNumber) {
 
     // We've been merged
     if (merged) {
-      const allPrereleases = releases.filter((r) => { // non-nightly prereleases
+      const allPrereleases = releases.filter((r) => { // get all prereleases (nightly, beta, alpha)
         let releaseTag = semver.parse(r.version).prerelease[0];
-        return releaseTag !== 'nightly' && releaseTag !== undefined; // filter out nightly and stable releases
+        return releaseTag !== undefined; // filter out stable releases
       });
       for (const prerelease of allPrereleases) {
         const dateParts = prerelease.date.split('-').map((n) => parseInt(n, 10));


### PR DESCRIPTION
#### Description of Change

<!-- Thank you for your Pull Request. Please describe your change here. -->
Fixed the issue: #30, by doing:

1.  **New Function**: Added getReleasesOrUpdateSortedByDate to sort releases by date from oldest to newest.
2.  **Usage**: used the new function in src/routes/pr.js to fetch releases, instead of the old one which was sorting alphabetically.
3.  **Logic Changes**:  Changed the filtration from choosing nightlies only to focusing on all prereleases (nightly, alpha, beta) as specified in the comment https://github.com/electron/release-status/issues/30#issuecomment-2182045114.
4.  **Refactoring**: Updated variable names and comments for clarity and readability.

**Question**: Can we use the function I created instead of the old one `getReleasesOrUpdate` function in `index.js`? If so I will only need to replace the old function logic with the new one.

### Now:
- For the PR #40634
![image](https://github.com/user-attachments/assets/dff4bac3-fd73-4963-b19f-87cbcbb28b32)

- For the PR #42368
![image](https://github.com/user-attachments/assets/49172d71-596a-4a82-b510-377ae68990fd)

These are the same results as in comment https://github.com/electron/release-status/issues/30#issuecomment-2182045114.


#### Checklist
<!-- Please confirm the following by changing [ ] to [x]. -->

- [x] This PR was not created with AI. (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.)
- [x] PR description included and stakeholders cc'd
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).
