### PR TITLE
fix: PR lookup table view for small screens

### DIFF
--- a/src/static/css/pr-lookup.css
+++ b/src/static/css/pr-lookup.css
@@ -1,6 +1,7 @@
 .lookup-container {
   width: 100%;
 }
+
 .lookup-input {
   text-align: center;
   margin-bottom: 20px;

--- a/src/static/css/pr-lookup.css
+++ b/src/static/css/pr-lookup.css
@@ -1,7 +1,5 @@
-.pr-lookup-container {
+.lookup-container {
   width: 100%;
-  height: 100%;
-  overflow: hidden;
 }
 .lookup-input {
   text-align: center;

--- a/src/static/css/pr-lookup.css
+++ b/src/static/css/pr-lookup.css
@@ -1,3 +1,8 @@
+.pr-lookup-container {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
 .lookup-input {
   text-align: center;
   margin-bottom: 20px;
@@ -103,4 +108,14 @@ tr:hover {
 
 tr:last-child td {
   border-bottom: none;
+}
+
+@media screen and (max-width: 600px) {
+  .recent-prs {
+    overflow-x: auto;
+    scroll-behavior: smooth;
+  }
+  .recent-prs::-webkit-scrollbar {
+    width: 0px;
+  }
 }

--- a/src/views/pr-lookup.handlebars
+++ b/src/views/pr-lookup.handlebars
@@ -1,4 +1,4 @@
-<div>
+<div class="pr-lookup-container">
 <div class="lookup-input">
   <form onsubmit="lookup(event)">
     <input id="input" type="text" placeholder="12345" required>

--- a/src/views/pr-lookup.handlebars
+++ b/src/views/pr-lookup.handlebars
@@ -1,4 +1,4 @@
-<div class="pr-lookup-container">
+<div class="lookup-container">
 <div class="lookup-input">
   <form onsubmit="lookup(event)">
     <input id="input" type="text" placeholder="12345" required>


### PR DESCRIPTION
This PR resolves the issue where the PR lookup table exceeded 100% width on small screens, causing layout issues and poor user experience.


Changes Implemented:
  
CSS Code example
```
 
.pr-lookup-container {
  width: 100%;
  height: 100%;
  overflow: hidden;
}

@media screen and (max-width: 600px) {
  .recent-prs {
    overflow-x: auto;
    scroll-behavior: smooth;
  }
  .recent-prs::-webkit-scrollbar {
    width: 0px;
  }
}

```

![Screenshot from 2025-04-02 23-28-13](https://github.com/user-attachments/assets/6ad03f2d-252f-41e2-8738-d958135586ff)


###Checklist
 The PR fixes the layout issue on small screens.
 The table is now responsive and scrollable on smaller devices.