### PR TITLE
build: update postinstall script to work cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "start": "node src/index.js",
     "lint": "prettier --check \"src/**/*.js\" \"src/**/*.css\"",
     "prettier:write": "prettier --write \"src/**/*.js\" \"src/**/*.css\"",
-    "postinstall": "cp node_modules/prismjs/themes/*.css src/static/css/prismjs",
+    "postinstall": "node -e \"require('fs').cpSync('./node_modules/prismjs/themes/', './src/static/css/prismjs/', { recursive: true })\"",
     "prepare": "husky"
   }
 }


### PR DESCRIPTION
#### Description of Change

This PR updates the `postinstall` script in `package.json` to use Node.js’s built-in `fs.cpSync` instead of the Unix-specific `cp` command, ensuring cross-platform compatibility without external dependencies, as requested by @erickzhao.

- Changed postinstall to use fs.cpSync as requested: `node -e 'fs.cpSync("./node_modules/prismjs/themes/", "./src/static/css/prismjs/", { recursive: true })'`.
- Restored yarn.lock to match upstream/main to avoid unintended changes.
- Tested on Windows 11 with Node.js 22.14.0.

#### Checklist

- [x] This PR was not created with AI.