### PR TITLE
fix(UI): fixed pr-look up responsive in all screens

### DIFF
--- a/src/views/layouts/main.handlebars
+++ b/src/views/layouts/main.handlebars
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Electron Releases</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-SgOJa3DmI69IUzQ2PVdRZhwQ+dy64/BUtbMJw1MZ8t5HZApcHrRKUc4W0kG879m7" crossorigin="anonymous">
     <link
       rel="shortcut icon"
       href="https://www.electronjs.org/assets/img/favicon.ico"
@@ -70,5 +71,6 @@
         window.location.href = `/release/compare/{{ compareTarget }}/${elem.value}`;
       }
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/js/bootstrap.bundle.min.js" integrity="sha384-k6d4wzSIapyDyv1kpU366/PK5hCdSbCRGRCMv+eplOQJWyd1fbcAu9OCUj5zNLiq" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/src/views/pr-lookup.handlebars
+++ b/src/views/pr-lookup.handlebars
@@ -1,4 +1,4 @@
-<div>
+<div class="table-responsive">
 <div class="lookup-input">
   <form onsubmit="lookup(event)">
     <input id="input" type="text" placeholder="12345" required>
@@ -7,7 +7,7 @@
 </div>
 <p class="error" id="error"></p>
 <div class="recent-prs">
-  <table>
+  <table class="table table-hover">
     <thead>
       <tr>
         <th>PR Number</th>


### PR DESCRIPTION
I fixed the pr-look up table issue now it is responsive in all screens, i just added some bootstrap classes to figure it out like:
"table-responsive" and made a feature to look attractive i.e on hover it gets a light background.