### PR TITLE
fix: improve responsive styling for body and navbar elements

### DIFF
--- a/src/static/css/styles.css
+++ b/src/static/css/styles.css
@@ -41,6 +41,13 @@ body {
   margin: 0;
 }
 
+@media screen and (max-width: 398px) {
+  body {
+    width: fit-content;
+    margin: 0 auto; /* Center the body horizontally */
+  }
+}
+
 * {
   box-sizing: border-box;
 }
@@ -115,6 +122,27 @@ footer > div {
     justify-content: center;
     margin-top: 8px;
     margin-bottom: 16px;
+  }
+}
+
+@media screen and (max-width: 576px) {
+  .navbar a {
+    margin-top: 8px;
+    justify-content: center;
+  }
+
+  .navbar > div > div {
+    justify-content: center;
+    margin-top: 8px;
+    margin-bottom: 16px;
+  }
+}
+
+@media screen and (max-width: 400px) {
+  .navbar > div {
+    width: 400px;
+    padding-right: 0px;
+    padding-left: 16px;
   }
 }
 


### PR DESCRIPTION
Included some media queries to adjust the user interface for smaller widths - 

1) If viewport width crosses below 398px , then the body tag width becomes equal to the content width .
2) If the viewport width crosses below 400px , then the navbar width remains 400px for all the viewports having width less than 400px and adjust the padding to make the items align in center

