### PR TITLE
fix: Cannot read properties of undefined (reading 'replace')

### DIFF
--- a/src/routes/release.js
+++ b/src/routes/release.js
@@ -197,14 +197,15 @@ router.get(
       return res.redirect('/');
     }
 
-    let releaseNotes = release.body ?? 'No data';
+    let releaseNotes = release.body;
     const parsed = semver.parse(version);
-    if (parsed.prerelease.length && releaseNotes !== 'No data') {
+    if (releaseNotes && parsed.prerelease.length) {
       releaseNotes = releaseNotes.split(new RegExp(`@${escapeRegExp(version.substr(1))}\`?.`))[1];
     }
-    releaseNotes =
-      '# Release Notes\n' +
-      releaseNotes.replace(/# Release Notes for [^\r\n]+(?:(?:\n)|(?:\r\n))/i, '');
+    releaseNotes = releaseNotes
+      ? '# Release Notes\n' +
+        releaseNotes.replace(/# Release Notes for [^\r\n]+(?:(?:\n)|(?:\r\n))/i, '')
+      : 'No data';
 
     const lastPreRelease = allReleases.find(
       (r) =>

--- a/src/routes/release.js
+++ b/src/routes/release.js
@@ -197,9 +197,9 @@ router.get(
       return res.redirect('/');
     }
 
-    let releaseNotes = release.body;
+    let releaseNotes = release.body ?? 'No data';
     const parsed = semver.parse(version);
-    if (parsed.prerelease.length) {
+    if (parsed.prerelease.length && releaseNotes !== 'No data') {
       releaseNotes = releaseNotes.split(new RegExp(`@${escapeRegExp(version.substr(1))}\`?.`))[1];
     }
     releaseNotes =


### PR DESCRIPTION
#### Description of Change
This PR solves #6  by adding a default value for release notes. In case if releaseNotes is null then it will use a default value and also avoids splitting of releaseNotes for default value

#### Checklist
<!-- Please confirm the following by changing [ ] to [x]. -->

- [x] This PR was not created with AI. (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.)
