### PR TITLE
fix: redirect legacy routes to new releases routes

### DIFF
--- a/app/redirects/release-build.tsx
+++ b/app/redirects/release-build.tsx
@@ -1,0 +1,6 @@
+import { LoaderFunctionArgs } from '@remix-run/node';
+import { redirect } from '@remix-run/react';
+
+export const loader = (args: LoaderFunctionArgs) => {
+  return redirect(`/build/${encodeURIComponent(args.params.id!)}`);
+};

--- a/app/redirects/releases.tsx
+++ b/app/redirects/releases.tsx
@@ -1,11 +1,15 @@
 import { LoaderFunctionArgs } from '@remix-run/node';
 import { redirect } from '@remix-run/react';
 
-const CHANNELS = ['stable', 'pre', 'nightly'];
+const channelsMap: Record<string, string | undefined> = {
+  stable: 'stable',
+  prerelease: 'pre',
+  nightly: 'nightly',
+};
 
 export const loader = (args: LoaderFunctionArgs) => {
-  let channel = args.params.channel || 'stable';
-  if (!CHANNELS.includes(channel)) {
+  let channel = channelsMap[args.params.channel || 'stable'];
+  if (!channel) {
     channel = 'stable';
   }
   return redirect(`/release?channel=${encodeURIComponent(channel)}`);

--- a/app/redirects/releases.tsx
+++ b/app/redirects/releases.tsx
@@ -1,0 +1,12 @@
+import { LoaderFunctionArgs } from '@remix-run/node';
+import { redirect } from '@remix-run/react';
+
+const CHANNELS = ['stable', 'pre', 'nightly'];
+
+export const loader = (args: LoaderFunctionArgs) => {
+  let channel = args.params.channel || 'stable';
+  if (!CHANNELS.includes(channel)) {
+    channel = 'stable';
+  }
+  return redirect(`/release?channel=${encodeURIComponent(channel)}`);
+};

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -1,11 +1,21 @@
 import { type RouteConfig, index, route } from '@remix-run/route-config';
 
+const redirect = (path: string, file: string) => {
+  return {
+    ...route(path, file),
+    id: path,
+  };
+};
+
 export default [
   // Home page
   index('routes/home.tsx'),
   // API routes
   route('releases.json', 'api/releases.ts'),
   route('active.json', 'api/active.ts'),
+  // Redirects
+  redirect('releases', 'redirects/releases.tsx'),
+  redirect('releases/:channel', 'redirects/releases.tsx'),
   // UI routes
   route('build/:id', 'routes/build/release-job.tsx'),
   route('history', 'routes/history.tsx'),

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -16,6 +16,7 @@ export default [
   // Redirects
   redirect('releases', 'redirects/releases.tsx'),
   redirect('releases/:channel', 'redirects/releases.tsx'),
+  redirect('release-build/:id', 'redirects/release-build.tsx'),
   // UI routes
   route('build/:id', 'routes/build/release-job.tsx'),
   route('history', 'routes/history.tsx'),


### PR DESCRIPTION
Fixes an issue that @dsanders11 noted where some old URLs weren't quite the same, this leaves the new URLs as "correct" and just redirects the old ones