### PR TITLE
style: align release table columns

### DIFF
--- a/app/components/ReleaseTable.tsx
+++ b/app/components/ReleaseTable.tsx
@@ -26,13 +26,13 @@ export const ReleaseTable = ({
         <table className="w-full">
           <thead>
             <tr className="bg-gray-50 dark:bg-gray-900/50 border-b border-gray-200 dark:border-gray-700">
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+              <th className="w-[225px] px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                 Version
               </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+              <th className="w-[350px] px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                 {showStability ? 'Stability' : 'Released'}
               </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+              <th className="w-[200px] px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                 Chromium
               </th>
               <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">


### PR DESCRIPTION
Makes all the numbers align across versions by fixing widths for certain columns. This only applies to the largest viewports, and smaller ones default to being responsive.

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/e81daff4-1c90-47df-84bb-6e90e9e62fa1) | ![image](https://github.com/user-attachments/assets/fafd607e-f026-4713-9f8a-c0a5f068a483) |

