### PR TITLE
fix(history): correct nightly percentage for current month

### DIFF
--- a/app/routes/history.tsx
+++ b/app/routes/history.tsx
@@ -202,13 +202,14 @@ export default function ReleaseHistory() {
           const isFutureMonth = year === new Date().getFullYear() && monthIndex > currentMonth;
           const isCurrentMonth = year === new Date().getFullYear() && monthIndex === currentMonth;
           const daysInMonth = getDaysInMonth(year, month);
+          const daysSoFar = isCurrentMonth ? currentDayOfMonth : daysInMonth;
 
           let missedNightlies = 0;
-          for (let i = 1; i <= daysInMonth; i++) {
+          for (let i = 1; i <= daysSoFar; i++) {
             missedNightlies += calendarData[month][i].missedNightly ? 1 : 0;
           }
           const nightlyPercentage =
-            Math.round(((daysInMonth - missedNightlies) / daysInMonth) * 10_000) / 100;
+            Math.round(((daysSoFar - missedNightlies) / daysSoFar) * 10_000) / 100;
 
           return (
             <div


### PR DESCRIPTION
Fixes the nightly percentage for the current month so that we only count days that have elapsed so far for the calculation.

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/c961dd82-104f-4e16-baf3-110ca3ba4020)| ![image](https://github.com/user-attachments/assets/6936a66d-0658-403b-a19b-aec0501404d6) |
