### PR TITLE
chore: standardize title meta tags

### DIFF
--- a/app/routes/build/release-job.tsx
+++ b/app/routes/build/release-job.tsx
@@ -15,7 +15,7 @@ import { guessTimeZoneFromRequest } from '~/helpers/timezone';
 
 export const meta: MetaFunction = (args) => {
   return [
-    { title: `Electron Release Job - ${args.params.id}` },
+    { title: `Job ${args.params.id} | Electron Releases` },
     {
       name: 'description',
       content: 'Live information about a specific Electron release job.',

--- a/app/routes/history.tsx
+++ b/app/routes/history.tsx
@@ -8,7 +8,7 @@ import { Select } from '~/components/Select';
 
 export const meta: MetaFunction = () => {
   return [
-    { title: 'Electron Release History' },
+    { title: 'History | Electron Releases' },
     {
       name: 'description',
       content: 'Calendar of Electron releases from the past year.',

--- a/app/routes/history/date.tsx
+++ b/app/routes/history/date.tsx
@@ -8,7 +8,7 @@ import { guessTimeZoneFromRequest } from '~/helpers/timezone';
 
 export const meta: MetaFunction = (args) => {
   return [
-    { title: `Electron Releases - ${args.params.date}` },
+    { title: `${args.params.date} | Electron Releases` },
     {
       name: 'description',
       content: `Electron releases on ${args.params.date}`,

--- a/app/routes/pr/details.tsx
+++ b/app/routes/pr/details.tsx
@@ -25,7 +25,7 @@ import { prettyDateString } from '~/helpers/time';
 
 export const meta: MetaFunction = (args) => {
   return [
-    { title: `Electron PR #${args.params.number}` },
+    { title: `PR #${args.params.number} | Electron Releases` },
     {
       name: 'description',
       content: `Details about Electron PR #${args.params.number}, including its status, author, and which Electron versions it was included in.`,

--- a/app/routes/pr/lookup.tsx
+++ b/app/routes/pr/lookup.tsx
@@ -9,7 +9,7 @@ import { guessTimeZoneFromRequest } from '~/helpers/timezone';
 
 export const meta: MetaFunction = () => {
   return [
-    { title: `Electron PR Lookup` },
+    { title: `PR Lookup | Electron Releases` },
     {
       name: 'description',
       content: `Lookup recent pull requests in Electron, including their details and which Electron versions they were included in.`,

--- a/app/routes/release/all.tsx
+++ b/app/routes/release/all.tsx
@@ -12,7 +12,7 @@ import { guessTimeZoneFromRequest } from '~/helpers/timezone';
 
 export const meta: MetaFunction = () => {
   return [
-    { title: 'Electron Releases' },
+    { title: 'All | Electron Releases' },
     {
       name: 'description',
       content: 'All historical Electron releases.',

--- a/app/routes/release/compare.tsx
+++ b/app/routes/release/compare.tsx
@@ -21,7 +21,7 @@ import { Select } from '~/components/Select';
 export const meta: MetaFunction = ({ params }) => {
   return [
     {
-      title: `Electron Compare - ${params.fromVersion} -> ${params.toVersion}`,
+      title: `Comparing ${params.fromVersion} -> ${params.toVersion} | Electron Releases`,
     },
     {
       name: 'description',

--- a/app/routes/release/single.tsx
+++ b/app/routes/release/single.tsx
@@ -25,7 +25,7 @@ import { Select } from '~/components/Select';
 
 export const meta: MetaFunction = ({ params }) => {
   return [
-    { title: `Electron ${params.version}` },
+    { title: `${params.version} | Electron Releases` },
     {
       name: 'description',
       content: `Electron ${params.version} - Release details`,


### PR DESCRIPTION
This follows what we do on electronjs.org by suffixing all page titles with `| Electron Releases`.

I think it makes having multiple tabs of the website easier to distinguish at a glance since we're not starting each page title with "Electron".