### PR TITLE
fix: make history pages switch faster

### DIFF
--- a/app/components/Select.tsx
+++ b/app/components/Select.tsx
@@ -5,9 +5,10 @@ type SelectProps = {
   options: string[];
   selected: string;
   onChange: (value: string) => void;
+  onClick?: () => void;
 };
 
-export const Select = ({ isDisabled, options, selected, onChange }: SelectProps) => {
+export const Select = ({ isDisabled, options, selected, onChange, onClick }: SelectProps) => {
   const onChangeHandler = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {
       const value = e.target.value;
@@ -22,9 +23,11 @@ export const Select = ({ isDisabled, options, selected, onChange }: SelectProps)
           className="px-4 py-2 rounded-lg border-r-8 border-transparent border outline outline-gray-200 dark:outline-gray-700 bg-white dark:bg-gray-800 text-base focus:outline-none focus:ring-2 focus:ring-[#2f3241] dark:focus:ring-[#9feaf9] transition-all"
           disabled={isDisabled}
           onChange={onChangeHandler}
+          onClick={onClick}
+          value={selected}
         >
           {options.map((opt) => (
-            <option key={opt} value={opt} selected={opt === selected}>
+            <option key={opt} value={opt}>
               {opt}
             </option>
           ))}

--- a/app/routes/build/release-job.tsx
+++ b/app/routes/build/release-job.tsx
@@ -30,6 +30,7 @@ export const loader = async (args: LoaderFunctionArgs) => {
     // Guess at three hours for the build time
     const estimatedCompletion = new Date(started.getTime() + 1_000 * 60 * 60 * 3);
     const timeZone = guessTimeZoneFromRequest(args.request);
+    args.context.cacheControl = 'private, max-age=30';
     return {
       ...build,
       started: prettyDateString(build.started, timeZone),

--- a/app/routes/release/compare.tsx
+++ b/app/routes/release/compare.tsx
@@ -89,6 +89,8 @@ export const loader = async (args: LoaderFunctionArgs) => {
     }),
   );
 
+  args.context.cacheControl = 'private, max-age=300';
+
   return {
     fromElectronRelease,
     toElectronRelease,


### PR DESCRIPTION
Adds some missing `cacheControl` values so that loader values are correctly cached when preloaded client side. Also adds manual instrumentation for other-year prefetching based on the select on the `History` page.