### PR TITLE
fix: handle case for v0 releases

### DIFF
--- a/app/routes/release/all.tsx
+++ b/app/routes/release/all.tsx
@@ -38,7 +38,7 @@ export const loader = async (args: LoaderFunctionArgs) => {
   }
   if (passedMajor?.startsWith('v')) {
     major = parseInt(passedMajor.substring(1), 10);
-    if (isNaN(major) || major <= 0) {
+    if (isNaN(major) || major < 0) {
       major = null;
     }
   }
@@ -63,7 +63,7 @@ export const loader = async (args: LoaderFunctionArgs) => {
       }
     })
     .filter((r) => {
-      if (major) {
+      if (major !== null) {
         return semverParse(r.version)!.major === major;
       }
       return true;


### PR DESCRIPTION
#### Description of Change
This PR handles the condition when major is set to `v0` by allowing major to be 0 and checking for `null` value only.

Before:

<img width="765" alt="image" src="https://github.com/user-attachments/assets/da42f6a7-5978-4038-8128-fbecfde970a9" />

After:

<img width="783" alt="image" src="https://github.com/user-attachments/assets/f85865a6-16e8-4fc7-952a-890917e40e60" />

#### Checklist
- [x] This PR was not created with AI. (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.)
