### PR TITLE
fixes #181 > Link to release pages from comparison page

### DIFF
--- a/app/components/VersionTimeline.tsx
+++ b/app/components/VersionTimeline.tsx
@@ -1,3 +1,5 @@
+import { Link } from '@remix-run/react';
+
 type VersionTimelineProps = {
   fromVersion: string;
   toVersion: string;
@@ -15,9 +17,12 @@ export const VersionTimeline = ({
         <div className="flex items-center min-w-max px-5 justify-center">
           <div className="flex flex-col items-center mr-2">
             <div className="w-4 h-4 rounded-full bg-blue-500"></div>
-            <span className="text-xs font-medium mt-1 text-blue-600 dark:text-blue-400 whitespace-nowrap">
+            <Link
+              to={`/release/${fromVersion}`}
+              className="text-xs font-medium mt-1 text-blue-600 dark:text-blue-400 whitespace-nowrap"
+            >
               {fromVersion}
-            </span>
+            </Link>
           </div>
 
           <div className="h-0.5 w-4 bg-gray-300 dark:bg-gray-700"></div>
@@ -27,9 +32,12 @@ export const VersionTimeline = ({
               <div key={version} className="flex items-center">
                 <div className="flex flex-col items-center mx-1">
                   <div className={`w-2 h-2 rounded-full bg-purple-500`}></div>
-                  <span className="text-[10px] font-medium mt-1 text-purple-600 dark:text-purple-400 whitespace-nowrap">
+                  <Link
+                    to={`/release/v${version}`}
+                    className="text-[10px] font-medium mt-1 text-purple-600 dark:text-purple-400 whitespace-nowrap"
+                  >
                     v{version}
-                  </span>
+                  </Link>
                 </div>
                 <div className="h-0.5 w-4 bg-gray-300 dark:bg-gray-700"></div>
               </div>
@@ -38,9 +46,12 @@ export const VersionTimeline = ({
 
           <div className="flex flex-col items-center ml-2">
             <div className="w-4 h-4 rounded-full bg-green-500"></div>
-            <span className="text-xs font-medium mt-1 text-green-600 dark:text-green-400 whitespace-nowrap">
+            <Link
+              to={`/release/${toVersion}`}
+              className="text-xs font-medium mt-1 text-green-600 dark:text-green-400 whitespace-nowrap"
+            >
               {toVersion}
-            </span>
+            </Link>
           </div>
         </div>
       </div>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -58,7 +58,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
       <body>
         <div className="min-h-screen bg-gradient-to-b from-gray-50 to-gray-100 dark:from-gray-900 dark:to-gray-950 flex flex-col">
           <header className="sticky top-0 z-10 bg-white/90 dark:bg-[#2f3241]/90 backdrop-blur-md border-b border-gray-200 dark:border-[#9feaf9]/10">
-            <div className="container mx-auto px-4 py-4 flex items-center justify-between flex flex-col sm:flex-row gap-4">
+            <div className="container mx-auto px-4 py-4 items-center justify-between flex flex-col sm:flex-row gap-4">
               <div className="flex items-center gap-2">
                 <Logo className="w-6 h-6 text-[#2f3241] dark:text-[#9feaf9]" />
                 <Link to="/" prefetch="intent">

--- a/app/routes/release/compare.tsx
+++ b/app/routes/release/compare.tsx
@@ -1,6 +1,13 @@
 import type { LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
 import { parse as semverParse, lt as semverLessThan, gt as semverGreaterThan } from 'semver';
-import { redirect, useLoaderData, useNavigate, useNavigation, useParams } from '@remix-run/react';
+import {
+  Link,
+  redirect,
+  useLoaderData,
+  useNavigate,
+  useNavigation,
+  useParams,
+} from '@remix-run/react';
 import {
   SiGooglechrome,
   SiGooglechromeHex,
@@ -226,8 +233,10 @@ export default function CompareReleases() {
 
               <div className="text-center mt-2">
                 <span className="text-xs text-gray-500 dark:text-gray-400">
-                  {toVersion} includes changes from {versionsBetween.length + 1} version
-                  {versionsBetween.length ? 's' : ''} since {fromVersion}
+                  <Link to={`/release/${toVersion}`}>{toVersion}</Link> includes changes from{' '}
+                  {versionsBetween.length + 1} version
+                  {versionsBetween.length ? 's' : ''} since{' '}
+                  <Link to={`/release/${fromVersion}`}>{fromVersion}</Link>
                 </span>
               </div>
             </div>
@@ -254,11 +263,12 @@ export default function CompareReleases() {
                             </div>
                             <div className="text-gray-700 dark:text-gray-300">
                               <div className="flex items-center gap-2 mb-1">
-                                <span
+                                <Link
+                                  to={`/release/v${version}`}
                                   className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-${color}-100 text-${color}-800 dark:bg-${color}-900/30 dark:text-${color}-400`}
                                 >
                                   {version}
-                                </span>
+                                </Link>
                               </div>
                               <div dangerouslySetInnerHTML={{ __html: content }}></div>
                             </div>


### PR DESCRIPTION

#### Description of Change

<!-- Thank you for your Pull Request. Please describe your change here. -->

fixes #181 

Now all the version labels from the compare page are clickable, and they navigate to their respective versions' release pages. edit file > compare.tsx, VersionTimeline.tsx, root.tsx(Minor change in class name as flex was given twice, removed that).

The change was done respecting to this image and as per instructions, all red labels are clickable.

<img width="1872" height="1480" alt="image" src="https://github.com/user-attachments/assets/87513ba4-56d7-4e38-bd4e-8caa074aad53" />

#### Checklist
<!-- Please confirm the following by changing [ ] to [x]. -->



- [ ] This PR was not created with AI. (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.)
