### PR TITLE
fix:  #191 add link to full commit log on comparison page

### DIFF
--- a/app/routes/release/compare.tsx
+++ b/app/routes/release/compare.tsx
@@ -135,6 +135,16 @@ export default function CompareReleases() {
             <h2 className="text-3xl font-bold text-[#2f3241] dark:text-white">
               Release Comparison
             </h2>
+            <div className="text-sm text-gray-500 dark:text-gray-400">
+              <a
+                href={`https://github.com/electron/electron/compare/v${fromVersion}...v${toVersion}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-500 hover:underline"
+              >
+                View full commit log
+              </a>
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
Closes #191

This PR adds a link to the full commit log on the release comparison page. The link is displayed below the "Release Comparison" heading and directs users to the GitHub compare view for the two selected Electron versions.