### PR TITLE
fix: release comparison with CRLF line endings

### DIFF
--- a/app/data/markdown.test.ts
+++ b/app/data/markdown.test.ts
@@ -210,4 +210,38 @@ describe('renderGroupedReleaseNotes', () => {
       }
     `);
   });
+
+  test('renders version grouped release notes correctly with CRLF line endings', () => {
+    const releaseNotes = [
+      {
+        version: 'v1.0.0',
+        content: '\r\n## New Feature\r\n\r\n* Added new feature\r\n',
+      },
+      {
+        version: 'v1.1.0',
+        content: '\r\n## New Feature\r\n\r\n* Added another feature\r\n',
+      },
+    ];
+
+    expect(renderGroupedReleaseNotes(releaseNotes)).toMatchInlineSnapshot(`
+      {
+        "New Feature": [
+          {
+            "content": "<ul>
+      <li><p class="mb-2 text-base text-gray-800 dark:text-gray-200">Added another feature</p></li>
+      </ul>
+      ",
+            "version": "v1.1.0",
+          },
+          {
+            "content": "<ul>
+      <li><p class="mb-2 text-base text-gray-800 dark:text-gray-200">Added new feature</p></li>
+      </ul>
+      ",
+            "version": "v1.0.0",
+          },
+        ],
+      }
+    `);
+  });
 });

--- a/app/data/markdown.ts
+++ b/app/data/markdown.ts
@@ -50,7 +50,7 @@ export const groupReleaseNotes = (versions: { version: string; content: string }
     groups[key] = [];
   }
   for (const { version, content } of versions) {
-    const headers = content.split(/^## ([A-Za-z ]+)\n/gm).slice(1);
+    const headers = content.split(/^## ([A-Za-z ]+)\r?\n/gm).slice(1);
     for (let i = 0; i < headers.length; i += 2) {
       const groupName = headers[i];
       const groupContent = headers[i + 1];


### PR DESCRIPTION
#### Description of Change

<!-- Thank you for your Pull Request. Please describe your change here. -->

Fixes https://releases.electronjs.org/release/compare/v40.8.5/v40.9.1.

For some reason, the 40.8.5 release notes use LF line endings (`\n`). 40.9.0 and 40.9.1 use CRLF line endings (`\r\n`).

Maybe because those release notes were edited manually?

#### Checklist
<!-- Please confirm the following by changing [ ] to [x]. -->

- [x] This PR was not created with AI. (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.)
