### PR TITLE
fix: don't cache empty releases on server error

### DIFF
--- a/app/data/release-data.test.ts
+++ b/app/data/release-data.test.ts
@@ -19,16 +19,6 @@ describe('getReleasesOrUpdate', () => {
     expect(await getReleasesOrUpdate()).toEqual([]);
   });
 
-  test('should return empty array when upstream json file errors', async () => {
-    fetchMock.doMockOnce(
-      () =>
-        new Response('[1]', {
-          status: 500,
-        }),
-    );
-    expect(await getReleasesOrUpdate()).toEqual([]);
-  });
-
   test('should return upstream content under normal conditions', async () => {
     fetchMock.mockResponseOnce('[{"version":"1.2.3","v8":"10.0"}]');
     expect(await getReleasesOrUpdate()).toEqual([{ version: '1.2.3', v8: '10.0' }]);

--- a/app/data/release-data.ts
+++ b/app/data/release-data.ts
@@ -19,7 +19,9 @@ export type ElectronRelease = {
 export const getReleasesOrUpdate = memoize(
   async () => {
     const response = await fetch('https://electronjs.org/headers/index.json');
-    if (response.status !== 200) return [];
+    if (response.status !== 200) {
+      throw new Error('Failed to fetch releases');
+    }
     const releases = (await response.json()) as ElectronRelease[];
     return releases
       .sort((a, b) => {


### PR DESCRIPTION
#### Description of Change

<!-- Thank you for your Pull Request. Please describe your change here. -->

We don't want to cache an empty placeholder value here, we want to throw an error, otherwise downstream users of `/releases.json` will incorrectly get an empty list of releases.

#### Checklist
<!-- Please confirm the following by changing [ ] to [x]. -->

- [x] This PR was not created with AI. (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.)
