### PR TITLE
feat: add release date to single release page

### DIFF
--- a/app/components/PageHeader.tsx
+++ b/app/components/PageHeader.tsx
@@ -9,10 +9,17 @@ type PageHeaderProps = {
   };
   title?: string;
   titleTags?: React.ReactNode[];
+  subtitle?: React.ReactNode;
   actionButton?: React.ReactNode;
 };
 
-export const PageHeader = ({ backTo, actionButton, title, titleTags }: PageHeaderProps) => {
+export const PageHeader = ({
+  backTo,
+  actionButton,
+  title,
+  titleTags,
+  subtitle,
+}: PageHeaderProps) => {
   return (
     <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-4 mb-8">
       {backTo ? (
@@ -28,11 +35,14 @@ export const PageHeader = ({ backTo, actionButton, title, titleTags }: PageHeade
         </div>
       ) : null}
       {title ? (
-        <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
-          <div className="flex items-center gap-3">
-            <h2 className="text-3xl font-bold text-[#2f3241] dark:text-white">{title}</h2>
-            {titleTags}
+        <div className="flex flex-col gap-1">
+          <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+              <h2 className="text-3xl font-bold text-[#2f3241] dark:text-white">{title}</h2>
+              {titleTags}
+            </div>
           </div>
+          {subtitle}
         </div>
       ) : null}
       {actionButton ? <div className="flex items-center gap-2">{actionButton}</div> : null}

--- a/app/components/ReleaseTable.tsx
+++ b/app/components/ReleaseTable.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router';
 import { ElectronRelease } from '~/data/release-data';
-import { humanFriendlyDaysSince, prettyReleaseDate } from '~/helpers/time';
+import { fullDateString, humanFriendlyDaysSince, prettyReleaseDate } from '~/helpers/time';
 
 type ReleaseTableProps = {
   releases: (ElectronRelease | undefined)[];
@@ -90,7 +90,10 @@ export const ReleaseTable = ({
                           className="px-6 py-4 flex-1"
                           prefetch="intent"
                         >
-                          <span className="flex items-center gap-2">
+                          <span
+                            className="flex items-center gap-2"
+                            title={fullDateString(release.fullDate, timeZone)}
+                          >
                             <span>{humanFriendlyDaysSince(release)}</span>
                             <span className="text-xs px-2 py-0.5 bg-gray-100 dark:bg-gray-700 rounded-full">
                               {prettyReleaseDate(release, timeZone)}

--- a/app/helpers/time.test.ts
+++ b/app/helpers/time.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'vitest';
-import { humanFriendlyDaysSince, prettyDateString, prettyReleaseDate } from './time';
+import {
+  fullDateString,
+  humanFriendlyDaysSince,
+  prettyDateString,
+  prettyReleaseDate,
+} from './time';
 
 describe('humanFriendlyDaysSince', () => {
   test('should return "Today" for today\'s date', () => {
@@ -84,5 +89,18 @@ describe('prettyDateString', () => {
     expect(prettyDateString('2020-01-31T23:59:59Z', 'UTC')).toBe('Jan 31, 2020, 11:59:59 PM');
     expect(prettyDateString('2020-12-31T00:00:00Z', 'UTC')).toBe('Dec 31, 2020, 12:00:00 AM');
     expect(prettyDateString('2020-02-29T12:00:00Z', 'UTC')).toBe('Feb 29, 2020, 12:00:00 PM');
+  });
+});
+
+describe('fullDateString', () => {
+  test('should format date correctly', () => {
+    expect(fullDateString('2020-02-02T12:00:00Z', 'UTC')).toBe('Feb 2, 2020, 12:00 PM UTC');
+    expect(fullDateString('2020-12-31T00:00:00Z', 'UTC')).toBe('Dec 31, 2020, 12:00 AM UTC');
+  });
+
+  test('should respect the given timezone', () => {
+    expect(fullDateString('2020-02-02T12:00:00Z', 'America/Los_Angeles')).toBe(
+      'Feb 2, 2020, 4:00 AM PST',
+    );
   });
 });

--- a/app/helpers/time.ts
+++ b/app/helpers/time.ts
@@ -57,3 +57,27 @@ export function prettyDateString(date: string, timeZone: string) {
     timeZone,
   });
 }
+
+/**
+ * This function requires a timezone, do not call it from inside a memoized or cached
+ * data function. Return a date string from those functions and in the loader apply
+ * the timezone with this function
+ *
+ * Intended for `title` attributes on abbreviated or relative dates
+ *
+ * @param date A date string from an ElectronRelease, or any parseable date string
+ * @returns The date formatted like Sep 9, 2026, 10:16 AM PDT
+ */
+export function fullDateString(date: string, timeZone: string) {
+  const d = new Date(date);
+  return d.toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+    timeZoneName: 'short',
+    timeZone,
+  });
+}

--- a/app/routes/release/single.tsx
+++ b/app/routes/release/single.tsx
@@ -9,6 +9,7 @@ import {
   SiV8,
   SiV8Hex,
 } from '@icons-pack/react-simple-icons';
+import { Calendar } from 'lucide-react';
 import { InstallCommand } from '~/components/InstallCommand';
 import { getGitHubReleaseNotes } from '~/data/github-data';
 import {
@@ -19,6 +20,8 @@ import {
 } from '~/data/release-data';
 import { renderMarkdownSafely } from '~/data/markdown';
 import { textPlainResponse, wantsTextPlain } from '~/helpers/request';
+import { fullDateString, humanFriendlyDaysSince, prettyReleaseDate } from '~/helpers/time';
+import { guessTimeZoneFromRequest } from '~/helpers/timezone';
 import { VersionInfo } from '~/components/VersionInfo';
 import { useCallback } from 'react';
 import { PageHeader } from '~/components/PageHeader';
@@ -75,6 +78,8 @@ export const loader = async (args: LoaderFunctionArgs) => {
     const lines = [
       `# Electron ${version}${tags.length ? ` (${tags.join(', ')})` : ''}`,
       '',
+      `Released: ${electronRelease.fullDate}`,
+      '',
       '## Install',
       '',
       '```',
@@ -102,6 +107,7 @@ export const loader = async (args: LoaderFunctionArgs) => {
     releaseNotesHTML: renderMarkdownSafely(releaseNotes),
     isLatestStable,
     isLatestPreRelease,
+    timeZone: guessTimeZoneFromRequest(args.request),
   };
 };
 
@@ -135,6 +141,18 @@ export default function SingleRelease() {
             )
           }
           title={`Electron ${version}`}
+          subtitle={
+            <div
+              className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400"
+              title={fullDateString(data.electronRelease.fullDate, data.timeZone)}
+            >
+              <Calendar className="w-4 h-4" />
+              <span>Released {prettyReleaseDate(data.electronRelease, data.timeZone)}</span>
+              <span className="text-xs px-2 py-0.5 bg-gray-100 dark:bg-gray-700 rounded-full">
+                {humanFriendlyDaysSince(data.electronRelease)}
+              </span>
+            </div>
+          }
           titleTags={[
             data.isLatestStable ? (
               <span


### PR DESCRIPTION
#### Description of Change

Currently the single release page doesn't show a release date. Also adds full timestamp titles for hover (like on GitHub) because that's nice.

<img width="365" height="92" alt="Release page timestamp" src="https://github.com/user-attachments/assets/8463ad7c-6eff-4731-b28f-5284290cef39" />

<img width="202" height="117" alt="Mobile release page timestamp" src="https://github.com/user-attachments/assets/fa9a2dde-8096-4037-8e1e-9c885b8de9be" />

<img width="240" height="74" alt="Timestamp on hover" src="https://github.com/user-attachments/assets/c653cb9b-810f-41b9-9ebd-4916b626c9a8" />